### PR TITLE
Adding a timeout for any PWR commands and setting to 10s. 

### DIFF
--- a/epson_projector/const.py
+++ b/epson_projector/const.py
@@ -96,6 +96,7 @@ EPSON_KEY_COMMANDS = {
 TIMEOUT_TIMES = {
     'TURN_ON': 40,
     'TURN_OFF': 10,
+    'PWR': 10,
     'SOURCE': 5,
     'ALL': 3
 }


### PR DESCRIPTION
This should fix a timeout error seen in Home Assistant.

The error is when sending a `get_property(POWER)` request, the request times out after 3 seconds. Testing has found that 5 seconds works (at least once), but increasing it to 10 may be more robust for other network configurations.

See the two issues below for context:

https://github.com/home-assistant/core/issues/38743

https://github.com/home-assistant/core/issues/30624