### PR TITLE
Raise exception instead of logging `Error request`

### DIFF
--- a/epson_projector/__init__.py
+++ b/epson_projector/__init__.py
@@ -1,5 +1,7 @@
 """Python library to control Epson projector."""
 
+from epson_projector.error import ProjectorError, ProjectorUnavailableError
+
 from epson_projector.projector import Projector
 
 from epson_projector.version import __version__

--- a/epson_projector/error.py
+++ b/epson_projector/error.py
@@ -1,0 +1,14 @@
+"""Error module."""
+
+
+class ProjectorError(Exception):
+    """Base class for errors."""
+
+    def __init__(self, *args, message=None, **_kwargs):
+        """Initialize base error."""
+
+        super().__init__(*args, message)
+
+
+class ProjectorUnavailableError(ProjectorError):
+    """Projector unavailable error."""

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -19,6 +19,7 @@ from .const import (
     SERIAL_BYTE,
     JSON_QUERY,
 )
+from .error import ProjectorUnavailableError
 from .timeout import get_timeout
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,8 +95,7 @@ class ProjectorHttp:
             TimeoutError,
             asyncio.exceptions.TimeoutError,
         ):
-            _LOGGER.error("Error request")
-            return STATE_UNAVAILABLE
+            raise ProjectorUnavailableError(STATE_UNAVAILABLE)
 
     async def get_serial(self):
         """Send TCP request for serial to Epson."""


### PR DESCRIPTION
Hey,

Currently, epson_projector just writes an `Error request` message to the Error level of log when any of `aiohttp.ClientError`, `aiohttp.ClientConnectionError`, `TimeoutError`, `asyncio.exceptions.TimeoutError` occur in the `send_request` method.

Since the library is said to be `Created mostly to use with Home Assistant.`, I suggest changing this behaviour to raise an exception. This exception can be later handled by HA and Epson integration and it can return a `Not ready` state for the device. It will prevent the following from happening when a device is offline and cannot be connected (8280 error messages in ~23 hours):

![image](https://user-images.githubusercontent.com/6554415/182876478-70bd029a-f0b4-4486-8a01-0c840a696567.png)

I know, this is not a perfect PR, but I hope the idea is clear and we can work on it. If the PR will be accepted, I will also prepare PR for the HA integration to handle the exception.