### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/epson_projector/version.py
+++ b/epson_projector/version.py
@@ -1,2 +1,2 @@
 """Version of Epson projector module."""
-__version__ = "0.4.6"
+__version__ = "0.5.0"


### PR DESCRIPTION
Hello, @pszafer,

Since the previous PR #17 has introduced a breaking change, I suppose, it would be better to change the version to 0.5.0, not to 0.4.7?

In any case, I have checked that everything will work well with the HA integration for Epson projectors, so I would kindly ask you to publish a new version to PyPI if this is fine with you. Then it can be accepted to the HA.

Thanks!