### PR TITLE
Switch to serial_asyncio_fast

### DIFF
--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -2,7 +2,7 @@
 import logging
 
 import asyncio
-import serial_asyncio
+import serial_asyncio_fast
 from serial.serialutil import SerialException
 from .const import ESCVP_HELLO_COMMAND, COLON, CR, GET_CR, BUSY, ERROR, SNO
 
@@ -45,7 +45,7 @@ class ProjectorSerial:
                 (
                     self._reader,
                     self._writer,
-                ) = await serial_asyncio.open_serial_connection(
+                ) = await serial_asyncio_fast.open_serial_connection(
                     url=self._host, baudrate=9600, loop=self._loop
                 )
                 if self._reader and self._writer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.3.0
-pyserial-asyncio-fast>=0.14
+pyserial-asyncio-fast>=0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.3.0
-pyserial_asyncio>=0.4
+pyserial-asyncio-fast>=0.14


### PR DESCRIPTION
I got the warning/error below in the HomeAssistant logs.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.12/site-packages/serial_asyncio/__init__.py", line 417, in _call_connection_lost
    self._serial.close()
  File "/usr/local/lib/python3.12/site-packages/serial/urlhandler/protocol_socket.py", line 104, in close
    time.sleep(0.3)
  File "/usr/src/homeassistant/homeassistant/util/loop.py", line 192, in protected_loop_func
    raise_for_blocking_call(
  File "/usr/src/homeassistant/homeassistant/util/loop.py", line 96, in raise_for_blocking_call
    raise RuntimeError(  # noqa: TRY200
RuntimeError: Caught blocking call to sleep with args (0.3,) in /usr/local/lib/python3.12/site-packages/serial/urlhandler/protocol_socket.py, line 104: time.sleep(0.3) inside the event loop; This is causing stability issues. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#sleep
```

As mentioned on the linked page this is caused by `serial_asyncio` and can be resolved by switching to `serial_asyncio_fast` which among other fixes also solves this issue.

This PR does the switch. 
Tested with the `test_serial.py` from the repo and works fine.

I intend to do the follow up PR in Home Assistant when a release with this change is made.