### PR TITLE
Use async contextmanager for timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Epson-projector module
-## Asynchronous library to control epson projectors
 
-Requires Python 3.5. asyncio, aiohttp.
+## Asynchronous library to control Epson projectors
+
+Requires Python 3.11 or higher.
 
 Created mostly to use with Home Assistant.
 
 ### Usage
 
-Check out test.py and const.py to see all posibilities to send to projector.
+Check out the test_*.py files and const.py to see all posibilities to send to projector.
 
 ```python
 """Test and example of usage of Epson module."""
@@ -33,5 +34,5 @@ async def run(websession):
     data = await projector.get_property(POWER)
     print(data)
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```

--- a/epson_projector/main.py
+++ b/epson_projector/main.py
@@ -120,7 +120,7 @@ class Projector:
                            type='json_query', command=False):
         """Send request to Epson."""
         try:
-            with async_timeout.timeout(timeout):
+            async with async_timeout.timeout(timeout):
                 url = '{url}{type}'.format(
                     url=self._http_url,
                     type=type)

--- a/epson_projector/main.py
+++ b/epson_projector/main.py
@@ -1,9 +1,9 @@
 """Main of Epson projector module."""
+import asyncio
 import logging
 import time
 
 import aiohttp
-import async_timeout
 
 from .const import (ACCEPT_ENCODING, ACCEPT_HEADER, ALL, DEFAULT_TIMEOUT_TIME, BUSY,
                     EPSON_KEY_COMMANDS, HTTP_OK, INV_SOURCES, SOURCE,
@@ -120,7 +120,7 @@ class Projector:
                            type='json_query', command=False):
         """Send request to Epson."""
         try:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 url = '{url}{type}'.format(
                     url=self._http_url,
                     type=type)

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -78,7 +78,7 @@ class ProjectorHttp:
     async def send_request(self, params, timeout, type=JSON_QUERY):
         """Send request to Epson."""
         try:
-            with async_timeout.timeout(timeout):
+            async with async_timeout.timeout(timeout):
                 url = "{url}{type}".format(url=self._http_url, type=type)
                 async with self.websession.get(
                     url=url, params=params, headers=self._headers
@@ -101,7 +101,7 @@ class ProjectorHttp:
         """Send TCP request for serial to Epson."""
         if not self._serial:
             try:
-                with async_timeout.timeout(10):
+                async with async_timeout.timeout(10):
                     power_on = await self.get_property(POWER, get_timeout(POWER))
                     if power_on == EPSON_CODES[POWER]:
                         reader, writer = await asyncio.open_connection(

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -3,7 +3,6 @@ import logging
 
 import aiohttp
 import asyncio
-import async_timeout
 
 from .const import (
     ACCEPT_ENCODING,
@@ -78,7 +77,7 @@ class ProjectorHttp:
     async def send_request(self, params, timeout, type=JSON_QUERY):
         """Send request to Epson."""
         try:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 url = "{url}{type}".format(url=self._http_url, type=type)
                 async with self.websession.get(
                     url=url, params=params, headers=self._headers
@@ -101,7 +100,7 @@ class ProjectorHttp:
         """Send TCP request for serial to Epson."""
         if not self._serial:
             try:
-                async with async_timeout.timeout(10):
+                async with asyncio.timeout(10):
                     power_on = await self.get_property(POWER, get_timeout(POWER))
                     if power_on == EPSON_CODES[POWER]:
                         reader, writer = await asyncio.open_connection(

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -42,7 +42,7 @@ class ProjectorSerial:
             except:
                 pass
         try:
-            with async_timeout.timeout(DEFAULT_TIMEOUT):
+            async with async_timeout.timeout(DEFAULT_TIMEOUT):
                 (
                     self._reader,
                     self._writer,
@@ -110,7 +110,7 @@ class ProjectorSerial:
             await self.async_init()
         if self._writer and self._isOpen and command:
             try:
-                with async_timeout.timeout(timeout):
+                async with async_timeout.timeout(timeout):
                     _LOGGER.debug("Sent to Epson: %r with timeout %d", command, timeout)
                     self._writer.write(command.encode())
                     response = await self._reader.readuntil(COLON.encode())

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -5,7 +5,6 @@ import asyncio
 import serial_asyncio
 from serial.serialutil import SerialException
 from .const import ESCVP_HELLO_COMMAND, COLON, CR, GET_CR, BUSY, ERROR, SNO
-import async_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ class ProjectorSerial:
             except:
                 pass
         try:
-            async with async_timeout.timeout(DEFAULT_TIMEOUT):
+            async with asyncio.timeout(DEFAULT_TIMEOUT):
                 (
                     self._reader,
                     self._writer,
@@ -110,7 +109,7 @@ class ProjectorSerial:
             await self.async_init()
         if self._writer and self._isOpen and command:
             try:
-                async with async_timeout.timeout(timeout):
+                async with asyncio.timeout(timeout):
                     _LOGGER.debug("Sent to Epson: %r with timeout %d", command, timeout)
                     self._writer.write(command.encode())
                     response = await self._reader.readuntil(COLON.encode())

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -43,7 +43,7 @@ class ProjectorTcp:
     async def async_init(self):
         """Async init to open connection with projector."""
         try:
-            with async_timeout.timeout(10):
+            async with async_timeout.timeout(10):
                 self._reader, self._writer = await asyncio.open_connection(
                     host=self._host, port=self._port, loop=self._loop
                 )
@@ -97,7 +97,7 @@ class ProjectorTcp:
             await self.async_init()
         if self._isOpen and command:
             bytes_to_read = bytes_to_read if bytes_to_read else 16
-            with async_timeout.timeout(timeout):
+            async with async_timeout.timeout(timeout):
                 self._writer.write(command.encode())
                 response = await self._reader.read(bytes_to_read)
                 response = response.decode().replace(CR_COLON, "")
@@ -109,7 +109,7 @@ class ProjectorTcp:
         """Send TCP request for serial to Epson."""
         if not self._serial:
             try:
-                with async_timeout.timeout(10):
+                async with async_timeout.timeout(10):
                     power_on = await self.get_property(POWER, get_timeout(POWER))
                     if power_on == EPSON_CODES[POWER]:
                         reader, writer = await asyncio.open_connection(

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -2,7 +2,6 @@
 import logging
 
 import asyncio
-import async_timeout
 
 from .const import (
     BUSY,
@@ -43,7 +42,7 @@ class ProjectorTcp:
     async def async_init(self):
         """Async init to open connection with projector."""
         try:
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 self._reader, self._writer = await asyncio.open_connection(
                     host=self._host, port=self._port, loop=self._loop
                 )
@@ -97,7 +96,7 @@ class ProjectorTcp:
             await self.async_init()
         if self._isOpen and command:
             bytes_to_read = bytes_to_read if bytes_to_read else 16
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 self._writer.write(command.encode())
                 response = await self._reader.read(bytes_to_read)
                 response = response.decode().replace(CR_COLON, "")
@@ -109,7 +108,7 @@ class ProjectorTcp:
         """Send TCP request for serial to Epson."""
         if not self._serial:
             try:
-                async with async_timeout.timeout(10):
+                async with asyncio.timeout(10):
                     power_on = await self.get_property(POWER, get_timeout(POWER))
                     if power_on == EPSON_CODES[POWER]:
                         reader, writer = await asyncio.open_connection(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiohttp>=3.3.0
 pyserial_asyncio>=0.4
-async_timeout>=3.0.0

--- a/test_http.py
+++ b/test_http.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Test and example of usage of Epson module."""
 import epson_projector as epson
 from epson_projector.const import POWER, VOLUME, PWR_ON
@@ -38,4 +40,4 @@ async def run(websession):
     # print(data)
 
 
-asyncio.get_event_loop().run_until_complete(main_web())
+asyncio.run(main_web())

--- a/test_serial.py
+++ b/test_serial.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import asyncio
 import epson_projector as epson
 from epson_projector.const import (POWER, PWR_ON, PWR_OFF)
@@ -37,6 +39,4 @@ async def run():
     print("Projector serial number:", serialno)
     projector.close()
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main_serial())
-loop.close()
+asyncio.run(main_serial())

--- a/test_tcp.py
+++ b/test_tcp.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import asyncio
 import epson_projector as epson
 from epson_projector.const import (POWER, PWR_OFF, VOLUME)
@@ -21,6 +23,4 @@ async def run():
     # await projector.send_command(PWR_OFF)
     # projector.close()
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main_tcp())
-loop.close()
+asyncio.run(main_tcp())


### PR DESCRIPTION
When trying to run `test_serial.py` I got following error.

```
/home/michel/epson_projector/./test_serial.py:40: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:epson_projector.projector:Getting POWER info
DEBUG:epson_projector.projector:Getting property PWR
DEBUG:epson_projector.projector_serial:Establishing serial connection
Traceback (most recent call last):
  File "/home/michel/epson_projector/./test_serial.py", line 41, in <module>
    loop.run_until_complete(main_serial())
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/michel/epson_projector/./test_serial.py", line 18, in main_serial
    await run()
  File "/home/michel/epson_projector/./test_serial.py", line 25, in run
    data = await projector.get_power()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michel/epson_projector/epson_projector/projector.py", line 69, in get_power
    power = await self.get_property(command=POWER)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michel/epson_projector/epson_projector/projector.py", line 80, in get_property
    return await self._projector.get_property(command=command, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michel/epson_projector/epson_projector/projector_serial.py", line 90, in get_property
    response = await self.send_request(timeout=timeout, command=command + GET_CR)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michel/epson_projector/epson_projector/projector_serial.py", line 111, in send_request
    await self.async_init()
  File "/home/michel/epson_projector/epson_projector/projector_serial.py", line 46, in async_init
    with async_timeout.timeout(DEFAULT_TIMEOUT):
TypeError: 'Timeout' object does not support the context manager protocol
```

This is because `async_timeout` dropped support for the sync context manager in version [5.0.0](https://github.com/aio-libs/async-timeout/releases/tag/v5.0.0) (which was deprecated in [4.0.0](https://github.com/aio-libs/async-timeout/releases/tag/v4.0.0)). Because `requirements.txt` says `async_timeout>=3.0.0` I ended up with version 5.0.1 installed.

To solve this I changed the calls to use the async contextmanager. The async context manager is also supported on version 3.0.0 of `async_timeout` so works without needing to change any dependecy versions.
I tested with `test_serial.py` and that works fine. I did not test the others.

On a sidenote, the `async_timeout` package as a whole has been deprecated in favor of using `asyncio.timeout` built into Python 3.11 or higher. If you don't mind bumping the minimum required Python version to 3.11 I can also update this PR to remove the need for `async_timeout` all together.