### PR TITLE
Make host and port configurable from commandine for test programs

### DIFF
--- a/test_http.py
+++ b/test_http.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 """Test and example of usage of Epson module."""
+import argparse
 import epson_projector as epson
 from epson_projector.const import POWER, VOLUME, PWR_ON
 
@@ -20,24 +21,31 @@ _LOGGER.setLevel(logging.DEBUG)
 logging.basicConfig(level=logging.DEBUG)
 
 
-async def main_web():
+async def main_web(args):
     """Run main with aiohttp ClientSession."""
-    async with aiohttp.ClientSession() as session:
-        await run(session)
+    async with aiohttp.ClientSession() as websession:
+        """Use Projector class of epson module and check if it is turned on."""
+        projector = epson.Projector(
+            host=args.host,
+            websession=websession,
+            type="http"
+        )
+        data = await projector.get_property(POWER)
+        print(data)
+    #    await projector.send_command(PWR_ON)
+        # data = await projector.send_request("EEMP0100À¨E")
+        # print(data)
 
 
-async def run(websession):
-    """Use Projector class of epson module and check if it is turned on."""
-    projector = epson.Projector(
-        host="192.168.11.45",
-        websession=websession,
-        type="http"
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Example/test application for Epson Projector package through http connection."
     )
-    data = await projector.get_property(POWER)
-    print(data)
-#    await projector.send_command(PWR_ON)
-    # data = await projector.send_request("EEMP0100À¨E")
-    # print(data)
 
+    parser.add_argument(
+        "host",
+        help="Hostname or IP address of the projector.",
+    )
+    args = parser.parse_args()
 
-asyncio.run(main_web())
+    asyncio.run(main_web(args))

--- a/test_serial.py
+++ b/test_serial.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import asyncio
 import epson_projector as epson
 from epson_projector.const import (POWER, PWR_ON, PWR_OFF)
@@ -15,13 +16,9 @@ _LOGGER.setLevel(logging.DEBUG)
 
 logging.basicConfig(level=logging.DEBUG)
 
-async def main_serial():
+async def main_serial(args):
     """Run main with serial connection."""
-    await run()
-
-
-async def run():
-    projector = epson.Projector(host='/dev/ttyUSB0',
+    projector = epson.Projector(host=args.serial_url,
                                 type='serial',
                                 timeout_scale=2.0)
     data = await projector.get_power()
@@ -39,4 +36,16 @@ async def run():
     print("Projector serial number:", serialno)
     projector.close()
 
-asyncio.run(main_serial())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Example/test application for Epson Projector package through serial connection."
+    )
+
+    parser.add_argument(
+        "serial_url",
+        help="Can be a devicename like /dev/ttyUSB0 or COM3 for real serial port or use socket://<ip-or-host>:<port> for connections to tcp-to-serial solutions.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main_serial(args))

--- a/test_tcp.py
+++ b/test_tcp.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
 
+import argparse
 import asyncio
 import epson_projector as epson
 from epson_projector.const import (POWER, PWR_OFF, VOLUME)
 
 
-async def main_tcp():
+async def main_tcp(args):
     """Run main with TCP session."""
-    await run()
-
-
-async def run():
-    projector = epson.Projector(host='192.168.11.37',
+    projector = epson.Projector(host=args.host,
                                 type='tcp')
     data = await projector.get_power()
     print(data)
@@ -23,4 +20,15 @@ async def run():
     # await projector.send_command(PWR_OFF)
     # projector.close()
 
-asyncio.run(main_tcp())
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(  # noqa: F821
+        description="Example/test application for Epson Projector package through tcp connection."
+    )
+
+    parser.add_argument(
+        "host",
+        help="Hostname or IP address of the projector.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main_tcp(args))

--- a/test_tcp.py
+++ b/test_tcp.py
@@ -18,7 +18,7 @@ async def main_tcp(args):
     dataa = await projector.get_serial_number()
     print("proj2", dataa)
     # await projector.send_command(PWR_OFF)
-    # projector.close()
+    projector.close()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(  # noqa: F821


### PR DESCRIPTION
Make the serial port/host configurable from the commandline.
This makes it easier to execute the applications without modifications on different setups.