### PR TITLE
Switch to serialx

### DIFF
--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -109,6 +109,7 @@ class ProjectorHttp(BaseProjectorConnection):
                         )
                         _LOGGER.debug("Asking for serial number.")
                         writer.write(SERIAL_BYTE)
+                        await writer.drain()
                         response = await reader.read(32)
                         self._serial = response[24:].decode()
                         writer.close()

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -3,7 +3,6 @@ import logging
 
 import asyncio
 import serialx
-from serial.serialutil import SerialException
 from .const import ESCVP_HELLO_COMMAND, COLON, CR, GET_CR, BUSY, ERROR, SNO
 from .base_connection import BaseProjectorConnection
 
@@ -62,7 +61,7 @@ class ProjectorSerial(BaseProjectorConnection):
                         )
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout error during connection")
-        except SerialException as se:
+        except (serialx.SerialException, OSError) as se:
             _LOGGER.error(f"Problem opening serial connection: {se}")
             self._isOpen = False
         return self.closed_connection_info()
@@ -123,7 +122,7 @@ class ProjectorSerial(BaseProjectorConnection):
                 _LOGGER.error("Timeout error during sending request %r", command)
                 self._timeouts += 1
                 self._check_timeout_reconnect()
-            except SerialException as se:
+            except (serialx.SerialException, OSError) as se:
                 _LOGGER.error(f"Error during serial write/read: {se}")
                 self.close()
 

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -50,6 +50,7 @@ class ProjectorSerial(BaseProjectorConnection):
                 if self._reader and self._writer:
                     self._isOpen = True
                     self._writer.write(ESCVP_HELLO_COMMAND.encode())
+                    await self._writer.drain()
                     response = await self._reader.readuntil(COLON.encode())
                     if str(response.decode().strip(CR)) == ":":
                         _LOGGER.info("Connection open")
@@ -111,6 +112,7 @@ class ProjectorSerial(BaseProjectorConnection):
                 async with asyncio.timeout(timeout):
                     _LOGGER.debug("Sent to Epson: %r with timeout %d", command, timeout)
                     self._writer.write(command.encode())
+                    await self._writer.drain()
                     response = await self._reader.readuntil(COLON.encode())
                     response = response[:-1].decode().rstrip(CR)
                     _LOGGER.debug("Response from Epson %r", response)

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -2,7 +2,7 @@
 import logging
 
 import asyncio
-import serial_asyncio_fast
+import serialx
 from serial.serialutil import SerialException
 from .const import ESCVP_HELLO_COMMAND, COLON, CR, GET_CR, BUSY, ERROR, SNO
 from .base_connection import BaseProjectorConnection
@@ -46,7 +46,7 @@ class ProjectorSerial(BaseProjectorConnection):
                 (
                     self._reader,
                     self._writer,
-                ) = await serial_asyncio_fast.open_serial_connection(
+                ) = await serialx.open_serial_connection(
                     url=self._host, baudrate=9600, loop=self._loop
                 )
                 if self._reader and self._writer:

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -29,7 +29,6 @@ class ProjectorSerial(BaseProjectorConnection):
         self._writer = None
         self._timeouts = 0
         self._isOpen = False
-        self._loop = asyncio.get_running_loop()
         self._serial = None
 
     async def async_init(self):
@@ -47,7 +46,7 @@ class ProjectorSerial(BaseProjectorConnection):
                     self._reader,
                     self._writer,
                 ) = await serialx.open_serial_connection(
-                    url=self._host, baudrate=9600, loop=self._loop
+                    url=self._host, baudrate=9600
                 )
                 if self._reader and self._writer:
                     self._isOpen = True

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -62,7 +62,7 @@ class ProjectorSerial(BaseProjectorConnection):
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout error during connection")
         except (serialx.SerialException, OSError) as se:
-            _LOGGER.error(f"Problem opening serial connection: {se}")
+            _LOGGER.error("Problem opening serial connection: %s", se)
             self._isOpen = False
         return self.closed_connection_info()
 
@@ -123,7 +123,7 @@ class ProjectorSerial(BaseProjectorConnection):
                 self._timeouts += 1
                 self._check_timeout_reconnect()
             except (serialx.SerialException, OSError) as se:
-                _LOGGER.error(f"Error during serial write/read: {se}")
+                _LOGGER.error("Error during serial write/read: %s", se)
                 self.close()
 
         return False

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -48,6 +48,7 @@ class ProjectorTcp(BaseProjectorConnection):
                     host=self._host, port=self._port, loop=self._loop
                 )
                 self._writer.write(ESCVPNET_HELLO_COMMAND.encode())
+                await self._writer.drain()
                 response = await self._reader.read(16)
                 if response[0:10].decode() == ESCVPNETNAME and response[14] == 32:
                     self._isOpen = True
@@ -99,6 +100,7 @@ class ProjectorTcp(BaseProjectorConnection):
             bytes_to_read = bytes_to_read if bytes_to_read else 16
             async with asyncio.timeout(timeout):
                 self._writer.write(command.encode())
+                await self._writer.drain()
                 response = await self._reader.read(bytes_to_read)
                 response = response.decode().replace(CR_COLON, "")
                 if response == ERROR:
@@ -117,6 +119,7 @@ class ProjectorTcp(BaseProjectorConnection):
                         )
                         _LOGGER.debug("Asking for serial number.")
                         writer.write(SERIAL_BYTE)
+                        await writer.drain()
                         response = await reader.read(32)
                         self._serial = response[24:].decode()
                         writer.close()

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -38,14 +38,13 @@ class ProjectorTcp(BaseProjectorConnection):
         self._port = port
         self._isOpen = False
         self._serial = None
-        self._loop = asyncio.get_running_loop()
 
     async def async_init(self):
         """Async init to open connection with projector."""
         try:
             async with asyncio.timeout(10):
                 self._reader, self._writer = await asyncio.open_connection(
-                    host=self._host, port=self._port, loop=self._loop
+                    host=self._host, port=self._port
                 )
                 self._writer.write(ESCVPNET_HELLO_COMMAND.encode())
                 await self._writer.drain()
@@ -115,7 +114,7 @@ class ProjectorTcp(BaseProjectorConnection):
                     power_on = await self.get_property(POWER, get_timeout(POWER))
                     if power_on == EPSON_CODES[POWER]:
                         reader, writer = await asyncio.open_connection(
-                            host=self._host, port=TCP_SERIAL_PORT, loop=self._loop
+                            host=self._host, port=TCP_SERIAL_PORT
                         )
                         _LOGGER.debug("Asking for serial number.")
                         writer.write(SERIAL_BYTE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.3.0
-pyserial-asyncio-fast>=0.16
+serialx>=1.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 
-types-pyserial
 mypy==1.16.0


### PR DESCRIPTION
Use [serialx ](https://github.com/puddly/serialx) instead of  pyserial.

Serialx is a modern alternative for Pyserial which has not had updates in many years. It provides a (mostly) pyserial compatible API making it easy to migrate. It also allows the usage of ESP Home proxies from Home Assistant introduced in 2026.5.0.