### PR TITLE
Add http password support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,20 @@ async def main():
     async with aiohttp.ClientSession() as session:
         await run(session)
 
+    # With a password
+    digest_auth = aiohttp.DigestAuthMiddleware(
+        login="EPSONWEB", password="YOUR_PASSWORD"
+    )
+    async with aiohttp.ClientSession(middlewares=[digest_auth]) as session:
+        await run(session)
+
+
 
 async def run(websession):
     """Use Projector class of epson module and check if it is turned on."""
     projector = epson.Projector(
         host='HOSTNAME',
-        websession=websession,
-        encryption=False)
+        websession=websession)
     data = await projector.get_property(POWER)
     print(data)
 

--- a/docs/HTTP_PROTOCOL.md
+++ b/docs/HTTP_PROTOCOL.md
@@ -1,0 +1,158 @@
+# Epson HTTP Protocol format
+
+This is mostly reverse-engineered from `epson_projector/projector_http.py` in [epson-projector](https://github.com/pszafer/epson_projector) and observations of communitcation with LS11000 projector.
+
+---
+
+## Endpoints
+
+The projector exposes an HTTP/CGI interface on port 80  
+
+There are two endpoints of interest for the usage of ESC/VP21 commands.
+
+| Endpoint              | Method | Purpose                              |
+|-----------------------|--------|--------------------------------------|
+| `/cgi-bin/json_query` | GET    | Query projector state (ESC/VP21 GET) |
+| `/cgi-bin/directsend` | GET    | Send a command (ESC/VP21 SET)        |
+
+Note that these are also offered on other endpoints like: `/cgi-bin/Remote/json_query`
+
+---
+
+## `GET /cgi-bin/json_query`
+
+Executes an ESC/VP21 GET command and returns the result as JSON.
+
+### Request
+
+```text
+GET /cgi-bin/json_query?jsoncallback=CMD?
+```
+
+The `jsoncallback` query parameter value is a literal ESC/VP21 GET command string, e.g. `PWR?`, `SOURCE?`, `VOL?` (note the ? at the end).
+
+### Response
+
+Generic format
+
+```json
+{
+  "projector": {
+    "feature": {
+      "name": "esc/vp21",
+      "query": "<command>",
+      "reply": "<value>",
+      "error": false
+    }
+  }
+}
+```
+
+`query` is the original query command it is responding to.
+`reply` is the raw ESC/VP21 response value.
+`error` is set when there was an error.
+
+Reponse from `PWR?` command
+
+```json
+{
+  "projector": {
+    "feature": {
+      "name": "esc/vp21",
+      "query": "PWR?",
+      "reply": "04",
+      "error": false
+    }
+  }
+}
+```
+
+Error response (missing ? at the end)
+
+```json
+{
+  "projector": {
+    "feature": {
+      "name": "esc/vp21",
+      "query": "PWR",
+      "reply": "ERR",
+      "error": true
+    }
+  }
+}
+```
+
+### Example
+
+This is captured from the webinterface
+
+```text
+GET /cgi-bin/json_query?jsoncallback=SOURCELIST?
+→ {
+  "projector": {
+    "feature": {
+      "name": "esc/vp21",
+      "query": "SOURCELIST?",
+      "reply": "30 HDMI1 A0 HDMI2",
+      "error": false
+    }
+  }
+}
+```
+
+---
+
+## `GET /cgi-bin/directsend`
+
+Sends an ESC/VP21 SET command.
+
+### Request: ESC/VP21 SET
+
+```text
+GET /cgi-bin/directsend?CMD=VALUE
+```
+
+The query parameter key is the ESC/VP21 command name, the value is the operand.
+
+```text
+GET /cgi-bin/directsend?CMODE=15
+GET /cgi-bin/directsend?ASPECT=00
+```
+
+### Response
+
+HTTP 200. The response is empty based on captures from the webinterface.
+
+## Authentication
+
+It seems like older models did not have (or require) authorization. Newer models (like LS11000) require it.
+
+The used method is [Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication) which is a wellknown standard.
+
+The user is "EPSONWEB"
+
+## CURL example
+
+This seems to be the minimal required to have a command succeed.
+
+Key points:
+
+* Use referrer header
+* Use digest authentication
+* Quote the URL to avoid issues with the `?` at the end
+
+```bash
+curl --digest --user EPSONWEB:password -H 'Referer: http://192.168.178.46/cgi-bin/webconf' "http://192.168.178.46/cgi-bin/json_query?jsoncallback=PWR?"
+```
+
+## Web UI observations
+
+Some observations from using the webinterface and watching the requests in the devtools.
+
+All requests seem to include an additional query parameter `_` which seems to be a timestamp. Might be linked to the authentication because the full URL is als in the `authorization` header.
+
+On the remote webpage the commands are sent to a different URL (note the `Remote` part).
+
+```text
+http://192.168.178.46/cgi-bin/Remote/directsend?KEY=3E&_=1779026817393
+```

--- a/docs/HTTP_PROTOCOL.md
+++ b/docs/HTTP_PROTOCOL.md
@@ -1,6 +1,6 @@
 # Epson HTTP Protocol format
 
-This is mostly reverse-engineered from `epson_projector/projector_http.py` in [epson-projector](https://github.com/pszafer/epson_projector) and observations of communitcation with LS11000 projector.
+This is mostly reverse-engineered from `epson_projector/projector_http.py` in [epson-projector](https://github.com/pszafer/epson_projector) and observations of communication with LS11000 projector.
 
 ---
 

--- a/docs/HTTP_PROTOCOL.md
+++ b/docs/HTTP_PROTOCOL.md
@@ -84,7 +84,7 @@ Error response (missing ? at the end)
 
 ### Example
 
-This is captured from the webinterface
+This is captured from the web interface
 
 ```text
 GET /cgi-bin/json_query?jsoncallback=SOURCELIST?
@@ -121,13 +121,13 @@ GET /cgi-bin/directsend?ASPECT=00
 
 ### Response
 
-HTTP 200. The response is empty based on captures from the webinterface.
+HTTP 200. The response is empty based on captures from the web interface.
 
 ## Authentication
 
 It seems like older models did not have (or require) authorization. Newer models (like LS11000) require it.
 
-The used method is [Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication) which is a wellknown standard.
+The used method is [Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication) which is a well-known standard.
 
 The user is "EPSONWEB"
 
@@ -147,9 +147,9 @@ curl --digest --user EPSONWEB:password -H 'Referer: http://192.168.178.46/cgi-bi
 
 ## Web UI observations
 
-Some observations from using the webinterface and watching the requests in the devtools.
+Some observations from using the web interface and watching the requests in the devtools.
 
-All requests seem to include an additional query parameter `_` which seems to be a timestamp. Might be linked to the authentication because the full URL is als in the `authorization` header.
+All requests seem to include an additional query parameter `_` which seems to be a timestamp. Might be linked to the authentication because the full URL is also in the `authorization` header.
 
 On the remote webpage the commands are sent to a different URL (note the `Remote` part).
 

--- a/docs/HTTP_PROTOCOL.md
+++ b/docs/HTTP_PROTOCOL.md
@@ -52,7 +52,7 @@ Generic format
 `reply` is the raw ESC/VP21 response value.
 `error` is set when there was an error.
 
-Reponse from `PWR?` command
+Response from `PWR?` command
 
 ```json
 {

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -22,6 +22,8 @@ The type "directsend" seems to be sending of plain ESC/VP21 commands. The type "
 
 The serial number of the projector seems to be obtained through the same way as done with `projector_tcp.py`.
 
+More details see: [HTTP_PROTOCOL.md](HTTP_PROTOCOL.md)
+
 ### ESC/VP.net
 
 This connection method is implemented in `protocol_tcp.py`

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -22,7 +22,7 @@ The type "directsend" seems to be sending of plain ESC/VP21 commands. The type "
 
 The serial number of the projector seems to be obtained through the same way as done with `projector_tcp.py`.
 
-More details see: [HTTP_PROTOCOL.md](HTTP_PROTOCOL.md)
+More details, see [HTTP_PROTOCOL.md](HTTP_PROTOCOL.md).
 
 ### ESC/VP.net
 

--- a/epson_projector/projector.py
+++ b/epson_projector/projector.py
@@ -32,6 +32,7 @@ class Projector:
         :param obj websession:  Websession to pass for HTTP protocol
         :param str type:        Type of connection to use ('http', 'tcp', 'serial')
         :param timeout_scale    Factor to multiply default timeouts by (for slow projectors)
+        :param int http_port:   Port to connect to for HTTP protocol. Default 80.
 
         """
         self._lock = Lock()

--- a/epson_projector/projector.py
+++ b/epson_projector/projector.py
@@ -23,6 +23,7 @@ class Projector:
         websession=None,
         type=HTTP,
         timeout_scale=1.0,
+        http_port=HTTP_PORT
     ):
         """
         Epson Projector controller.
@@ -41,7 +42,7 @@ class Projector:
         if self._type == HTTP:
             from .projector_http import ProjectorHttp
             self._projector = ProjectorHttp(
-                host=host, websession=websession, port=HTTP_PORT
+                host=host, websession=websession, port=http_port
             )
         elif self._type == TCP:
             from .projector_tcp import ProjectorTcp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.3.0
+aiohttp>=3.12.0
 serialx>=1.2.2

--- a/test_http.py
+++ b/test_http.py
@@ -23,7 +23,16 @@ logging.basicConfig(level=logging.DEBUG)
 
 async def main_web(args):
     """Run main with aiohttp ClientSession."""
-    async with aiohttp.ClientSession() as websession:
+
+    middlewares = []
+    if args.password:
+        _LOGGER.info("Using password for authentication")
+        digest_auth = aiohttp.DigestAuthMiddleware(
+            login="EPSONWEB", password=args.password
+        )
+        middlewares.append(digest_auth)
+
+    async with aiohttp.ClientSession(middlewares=middlewares) as websession:
         """Use Projector class of epson module and check if it is turned on."""
         projector = epson.Projector(
             host=args.host,
@@ -45,6 +54,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "host",
         help="Hostname or IP address of the projector.",
+    )
+    parser.add_argument(
+        "--password",
+        help="Password for the projector. Leave empty if not needed.",
     )
     args = parser.parse_args()
 

--- a/test_http.py
+++ b/test_http.py
@@ -37,7 +37,8 @@ async def main_web(args):
         projector = epson.Projector(
             host=args.host,
             websession=websession,
-            type="http"
+            type="http",
+            http_port=args.port,
         )
         data = await projector.get_property(POWER)
         print(data)
@@ -54,6 +55,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "host",
         help="Hostname or IP address of the projector.",
+    )
+    parser.add_argument(
+        "--port",
+        help="Port of the projector. Usually not needed, but helpful when connecting to an emulator.",
+        default=80,
     )
     parser.add_argument(
         "--password",


### PR DESCRIPTION
Add support for password protected http access.

This seems required by LS11000 and probably others.

Technically it now needs to be setup outside of the library as part of the websession. But at least it is documented how it works.

I would prefer to have the library just get the password and do all the session configuration internally, but that woud break the existing API and Home Assistant seems to prefer passing in the websession.