### PR TITLE
Improve serial number retrieval for http

### DIFF
--- a/epson_projector/const.py
+++ b/epson_projector/const.py
@@ -129,6 +129,7 @@ EPSON_KEY_COMMANDS = {
     "LENSMEMORY_8": [("POPLP", "08")],
     "LENSMEMORY_9": [("POPLP", "09")],
     "LENSMEMORY_10": [("POPLP", "0A")],
+    "SNO": [("jsoncallback", "SNO?")],
 }
 
 DEFAULT_TIMEOUT_TIME = 3

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -11,6 +11,7 @@ from .const import (
     EPSON_KEY_COMMANDS,
     DIRECT_SEND,
     HTTP_OK,
+    SNO,
     STATE_UNAVAILABLE,
     POWER,
     EPSON_CODES,
@@ -97,7 +98,16 @@ class ProjectorHttp(BaseProjectorConnection):
             raise ProjectorUnavailableError(STATE_UNAVAILABLE)
 
     async def get_serial_number(self):
-        """Send TCP request for serial number to Epson."""
+        """Request for serial number to Epson."""
+
+        # First attempt to get serial number through get_property
+        # This command also works when the projector is in standby
+        if not self._serial:
+            response = await self.get_property(SNO, get_timeout(SNO))
+            if response and response != BUSY and response != STATE_UNAVAILABLE:
+                self._serial = response
+
+        # Otherwise fallback to the same method as used for TCP request for serial number
         if not self._serial:
             try:
                 async with asyncio.timeout(10):
@@ -119,4 +129,5 @@ class ProjectorHttp(BaseProjectorConnection):
                 _LOGGER.error(
                     "Timeout error receiving SERIAL of projector. Is projector turned on?"
                 )
+
         return self._serial

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -88,7 +88,6 @@ class ProjectorHttp(BaseProjectorConnection):
                     if response.status != HTTP_OK:
                         _LOGGER.warning("Error message %d from Epson.", response.status)
                         return False
-                    _LOGGER.debug("Received response, content: %s", await response.text())
                     if type == JSON_QUERY:
                         return await response.json()
                     return response

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -106,9 +106,9 @@ class ProjectorHttp(BaseProjectorConnection):
         # This command also works when the projector is in standby
         if not self._serial:
             try:
-                 response = await self.get_property(SNO, get_timeout(SNO))
+                response = await self.get_property(SNO, get_timeout(SNO))
             except ProjectorUnavailableError:
-                 response = False
+                response = False
             else:
                 if response and response != BUSY and response != STATE_UNAVAILABLE:
                     self._serial = response

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -80,12 +80,15 @@ class ProjectorHttp(BaseProjectorConnection):
         try:
             async with asyncio.timeout(timeout):
                 url = "{url}{type}".format(url=self._http_url, type=type)
+                _LOGGER.debug("Sending request: %s", params)
                 async with self.websession.get(
                     url=url, params=params, headers=self._headers
                 ) as response:
+                    _LOGGER.debug("Received response, status: %s", response.status)
                     if response.status != HTTP_OK:
                         _LOGGER.warning("Error message %d from Epson.", response.status)
                         return False
+                    _LOGGER.debug("Received response, content: %s", await response.text())
                     if type == JSON_QUERY:
                         return await response.json()
                     return response

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -105,9 +105,13 @@ class ProjectorHttp(BaseProjectorConnection):
         # First attempt to get serial number through get_property
         # This command also works when the projector is in standby
         if not self._serial:
-            response = await self.get_property(SNO, get_timeout(SNO))
-            if response and response != BUSY and response != STATE_UNAVAILABLE:
-                self._serial = response
+            try:
+                 response = await self.get_property(SNO, get_timeout(SNO))
+            except ProjectorUnavailableError:
+                 response = False
+            else:
+                if response and response != BUSY and response != STATE_UNAVAILABLE:
+                    self._serial = response
 
         # Otherwise fallback to the same method as used for TCP request for serial number
         if not self._serial:
@@ -127,6 +131,8 @@ class ProjectorHttp(BaseProjectorConnection):
                         writer.close()
                     else:
                         _LOGGER.error("Is projector turned on?")
+            except ProjectorUnavailableError:
+                _LOGGER.error("Projector unavailable. Is projector connected and turned on?")
             except asyncio.TimeoutError:
                 _LOGGER.error(
                     "Timeout error receiving SERIAL of projector. Is projector turned on?"

--- a/test_http.py
+++ b/test_http.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     )
-    
+
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel)

--- a/test_http.py
+++ b/test_http.py
@@ -42,6 +42,8 @@ async def main_web(args):
         )
         data = await projector.get_property(POWER)
         print(data)
+        data = await projector.get_serial_number()
+        print(data)
     #    await projector.send_command(PWR_ON)
         # data = await projector.send_request("EEMP0100À¨E")
         # print(data)

--- a/test_http.py
+++ b/test_http.py
@@ -11,15 +11,6 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-)
-_LOGGER.addHandler(console_handler)
-_LOGGER.setLevel(logging.DEBUG)
-
-logging.basicConfig(level=logging.DEBUG)
-
 
 async def main_web(args):
     """Run main with aiohttp ClientSession."""
@@ -67,6 +58,15 @@ if __name__ == "__main__":
         "--password",
         help="Password for the projector. Leave empty if not needed.",
     )
+    parser.add_argument(
+        "--loglevel",
+        help="Set the logging level. Default is INFO.",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+    
     args = parser.parse_args()
+
+    logging.basicConfig(level=args.loglevel)
 
     asyncio.run(main_web(args))


### PR DESCRIPTION
The old method to get the serial number for HTTP does not work on EH-LS11000W. The port 3620 that is used is for that is not supported on that model. I can't really find good info about that protocol.

This PR updatess `get_serial_number` to use a `get_property` request to retrieve the serial number. It also has the benefit that iw  works when projector is in standby.

Fallback to the previous method when `get_property` did not result in a response.

Tested on EH-LS11000W