### PR TITLE
Revert Improve serial number retrieval for http

### DIFF
--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -101,19 +101,6 @@ class ProjectorHttp(BaseProjectorConnection):
 
     async def get_serial_number(self):
         """Request for serial number to Epson."""
-
-        # First attempt to get serial number through get_property
-        # This command also works when the projector is in standby
-        if not self._serial:
-            try:
-                response = await self.get_property(SNO, get_timeout(SNO))
-            except ProjectorUnavailableError:
-                response = False
-            else:
-                if response and response != BUSY and response != STATE_UNAVAILABLE:
-                    self._serial = response
-
-        # Otherwise fallback to the same method as used for TCP request for serial number
         if not self._serial:
             try:
                 async with asyncio.timeout(10):


### PR DESCRIPTION
While implementing a similar change for TCP I realized that SNO? returns a serialnumber of 11 characters. The code in `get_serial_number`  only reads 8 bytes, so either it cuts off part of the serial number or it is a different number then what SNO gives back.

Introducing SNO like this for http would break the configentry unique_id in HA, so reverting the change made in #33 until there is a better understanding.

I would like to use SNO in the future because it seems to work for more projectors (at least serial connected and LS11000 http+tcp). It is also a normal ESC/VP21 command.