### PR TITLE
Bump pytest and pytest-asyncio

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
 mypy==1.16.0
-pytest==8.3.5
-pytest-asyncio==0.26.0
+pytest==9.0.3
+pytest-asyncio==1.4.0


### PR DESCRIPTION
Bump pytest and pytest-asyncio together. Dependabot can't do it automatically and it should resolve the security message