### PR TITLE
Update creating projector instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,33 +13,20 @@ Check out the test_*.py files and const.py to see all posibilities to send to pr
 ```python
 """Test and example of usage of Epson module."""
 import epson_projector as epson
-from epson_projector.const import (POWER)
+from epson_projector.const import POWER
 
 import asyncio
-import aiohttp
-
 
 async def main():
-    """Run main with aiohttp ClientSession."""
-    async with aiohttp.ClientSession() as session:
-        await run(session)
-
-    # With a password
-    digest_auth = aiohttp.DigestAuthMiddleware(
-        login="EPSONWEB", password="YOUR_PASSWORD"
-    )
-    async with aiohttp.ClientSession(middlewares=[digest_auth]) as session:
-        await run(session)
-
-
-
-async def run(websession):
     """Use Projector class of epson module and check if it is turned on."""
-    projector = epson.Projector(
+    projector = epson.Projector.create_http(
         host='HOSTNAME',
-        websession=websession)
+        password='PASSWORD_IF_NEEDED'
+    )
     data = await projector.get_property(POWER)
     print(data)
+
+    await projector.close()
 
 asyncio.run(main())
 ```

--- a/epson_projector/base_connection.py
+++ b/epson_projector/base_connection.py
@@ -27,6 +27,6 @@ class BaseProjectorConnection(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def close(self):
+    async def close(self):
         """Close the connection."""
         pass

--- a/epson_projector/const.py
+++ b/epson_projector/const.py
@@ -1,8 +1,5 @@
 """Const helpers of Epson projector module."""
 
-HTTP = "http"
-TCP = "tcp"
-SERIAL = "serial"
 HTTP_OK = 200
 
 TCP_PORT = 3629

--- a/epson_projector/const.py
+++ b/epson_projector/const.py
@@ -1,9 +1,5 @@
 """Const helpers of Epson projector module."""
 
-HTTP = "http"
-TCP = "tcp"
-SERIAL = "serial"
-
 EASYMP_PORT = 3620
 EEMP0100 = "45454d5030313030"
 SERIAL_COMMAND = "0000000002000000"

--- a/epson_projector/projector.py
+++ b/epson_projector/projector.py
@@ -2,7 +2,7 @@
 import logging
 
 from .base_connection import BaseProjectorConnection
-from .const import BUSY, TCP_PORT, HTTP_PORT, POWER, HTTP, TCP, SERIAL
+from .const import BUSY, TCP_PORT, HTTP_PORT, POWER
 from .timeout import get_timeout
 
 from .lock import Lock
@@ -19,43 +19,80 @@ class Projector:
 
     def __init__(
         self,
-        host,
-        websession=None,
-        type=HTTP,
+        connection: BaseProjectorConnection,
         timeout_scale=1.0,
-        http_port=HTTP_PORT,
-        tcp_password=None
     ):
         """
         Epson Projector controller.
 
-        :param str host:         Hostname/IP/serial to the projector
-        :param obj websession:   Websession to pass for HTTP protocol
-        :param str type:         Type of connection to use ('http', 'tcp', 'serial')
+        :param BaseProjectorConnection connection: Pre-initialized connection to use.
         :param timeout_scale     Factor to multiply default timeouts by (for slow projectors)
-        :param int http_port:    Port to connect to for HTTP protocol. Default 80.
-        :param str tcp_password: Password for the TCP connection.
         """
         self._lock = Lock()
-        self._type = type
         self._timeout_scale = timeout_scale
         self._power = None
-        self._projector:BaseProjectorConnection
-        if self._type == HTTP:
-            from .projector_http import ProjectorHttp
-            self._projector = ProjectorHttp(
-                host=host, websession=websession, port=http_port
+        self._projector = connection
+
+    @staticmethod
+    def create_http(
+        host: str,
+        password: str | None = None,
+        port: int = HTTP_PORT,
+        timeout_scale=1.0,
+    ) -> "Projector":
+        """
+        Create an Epson Projector connected through HTTP.
+
+        :param str host:             Hostname/IP/serial to the projector
+        :param str | None password:  Optional password for HTTP
+        :param int port:             HTTP port. Default 80.
+        :param timeout_scale         Factor to multiply default timeouts by (for slow projectors)
+        """
+        from .projector_http import ProjectorHttp
+        import aiohttp
+
+        middlewares = []
+        if password:
+            digest_auth = aiohttp.DigestAuthMiddleware(
+                login="EPSONWEB", password=password
             )
-        elif self._type == TCP:
-            from .projector_tcp import ProjectorTcp
-            self._projector = ProjectorTcp(host, TCP_PORT, password=tcp_password)
-        elif self._type == SERIAL:
-            from .projector_serial import ProjectorSerial
-            self._projector = ProjectorSerial(host)
-        else:
-            raise ValueError(
-                f"Invalid type {self._type}."
-            )
+            middlewares.append(digest_auth)
+        websession = aiohttp.ClientSession(middlewares=middlewares)
+
+        return Projector(connection=ProjectorHttp(
+            host=host, websession=websession, port=port
+        ), timeout_scale=timeout_scale)
+
+    @staticmethod
+    def create_escvpnet(
+        host: str,
+        password: str | None = None,
+        timeout_scale=1.0
+    ) -> "Projector":
+        """
+        Create an Epson Projector connected through ESC/VP.net.
+
+        :param str host:             Hostname/IP/serial to the projector
+        :param str | None password:  Optional password for ESC/VP.net connection
+        :param timeout_scale     Factor to multiply default timeouts by (for slow projectors)
+        """
+        from .projector_tcp import ProjectorTcp
+        return Projector(connection=ProjectorTcp(host, TCP_PORT, password=password), timeout_scale=timeout_scale)
+
+    @staticmethod
+    def create_serial(
+        url: str,
+        timeout_scale=1.0,
+    ) -> "Projector":
+        """
+        Create an Epson Projector connected through serial.
+
+        :param str url:          Serialx supported URL for the projector
+        :param timeout_scale     Factor to multiply default timeouts by (for slow projectors)
+        """
+        from .projector_serial import ProjectorSerial
+        return Projector(connection=ProjectorSerial(url), timeout_scale=timeout_scale)
+
 
     def close(self):
         """Close connection."""

--- a/epson_projector/projector.py
+++ b/epson_projector/projector.py
@@ -1,4 +1,6 @@
 """Main of Epson projector module."""
+from __future__ import annotations
+
 import logging
 
 from .base_connection import BaseProjectorConnection
@@ -33,13 +35,14 @@ class Projector:
         self._power = None
         self._projector = connection
 
-    @staticmethod
+    @classmethod
     def create_http(
+        cls,
         host: str,
         password: str | None = None,
         port: int = HTTP_PORT,
         timeout_scale=1.0,
-    ) -> "Projector":
+    ) -> Projector:
         """
         Create an Epson Projector connected through HTTP.
 
@@ -50,16 +53,17 @@ class Projector:
         """
         from .projector_http import ProjectorHttp
 
-        return Projector(connection=ProjectorHttp(
+        return cls(connection=ProjectorHttp(
             host=host, password=password, port=port
         ), timeout_scale=timeout_scale)
 
-    @staticmethod
+    @classmethod
     def create_escvpnet(
+        cls,
         host: str,
         password: str | None = None,
         timeout_scale=1.0
-    ) -> "Projector":
+    ) -> Projector:
         """
         Create an Epson Projector connected through ESC/VP.net.
 
@@ -68,13 +72,14 @@ class Projector:
         :param timeout_scale     Factor to multiply default timeouts by (for slow projectors)
         """
         from .projector_tcp import ProjectorTcp
-        return Projector(connection=ProjectorTcp(host, TCP_PORT, password=password), timeout_scale=timeout_scale)
+        return cls(connection=ProjectorTcp(host, TCP_PORT, password=password), timeout_scale=timeout_scale)
 
-    @staticmethod
+    @classmethod
     def create_serial(
+        cls,
         url: str,
         timeout_scale=1.0,
-    ) -> "Projector":
+    ) -> Projector:
         """
         Create an Epson Projector connected through serial.
 
@@ -82,7 +87,7 @@ class Projector:
         :param timeout_scale     Factor to multiply default timeouts by (for slow projectors)
         """
         from .projector_serial import ProjectorSerial
-        return Projector(connection=ProjectorSerial(url), timeout_scale=timeout_scale)
+        return cls(connection=ProjectorSerial(url), timeout_scale=timeout_scale)
 
 
     async def close(self):

--- a/epson_projector/projector.py
+++ b/epson_projector/projector.py
@@ -49,18 +49,9 @@ class Projector:
         :param timeout_scale         Factor to multiply default timeouts by (for slow projectors)
         """
         from .projector_http import ProjectorHttp
-        import aiohttp
-
-        middlewares = []
-        if password:
-            digest_auth = aiohttp.DigestAuthMiddleware(
-                login="EPSONWEB", password=password
-            )
-            middlewares.append(digest_auth)
-        websession = aiohttp.ClientSession(middlewares=middlewares)
 
         return Projector(connection=ProjectorHttp(
-            host=host, websession=websession, port=port
+            host=host, password=password, port=port
         ), timeout_scale=timeout_scale)
 
     @staticmethod
@@ -94,9 +85,9 @@ class Projector:
         return Projector(connection=ProjectorSerial(url), timeout_scale=timeout_scale)
 
 
-    def close(self):
+    async def close(self):
         """Close connection."""
-        self._projector.close()
+        await self._projector.close()
 
     def set_timeout_scale(self, timeout_scale=1.0):
         """Set timeout scale for commands (to compensate for slow projectors)."""

--- a/epson_projector/projector.py
+++ b/epson_projector/projector.py
@@ -43,7 +43,7 @@ class Projector:
         """
         Create an Epson Projector connected through HTTP.
 
-        :param str host:             Hostname/IP/serial to the projector
+        :param str host:             Hostname/IP to the projector
         :param str | None password:  Optional password for HTTP
         :param int port:             HTTP port. Default 80.
         :param timeout_scale         Factor to multiply default timeouts by (for slow projectors)
@@ -63,7 +63,7 @@ class Projector:
         """
         Create an Epson Projector connected through ESC/VP.net.
 
-        :param str host:             Hostname/IP/serial to the projector
+        :param str host:             Hostname/IP to the projector
         :param str | None password:  Optional password for ESC/VP.net connection
         :param timeout_scale     Factor to multiply default timeouts by (for slow projectors)
         """

--- a/epson_projector/projector_http.py
+++ b/epson_projector/projector_http.py
@@ -11,6 +11,7 @@ from .const import (
     EPSON_KEY_COMMANDS,
     DIRECT_SEND,
     HTTP_OK,
+    HTTP_PORT,
     SNO,
     STATE_UNAVAILABLE,
     POWER,
@@ -33,12 +34,12 @@ class ProjectorHttp(BaseProjectorConnection):
     Control your projector with Python.
     """
 
-    def __init__(self, host, websession, port=80):
+    def __init__(self, host, password: str | None = None, port=HTTP_PORT):
         """
         Epson Projector controller.
 
         :param str host:        IP address or hostname of Projector
-        :param obj websession:  AioHttpWebsession for HTTP protocol
+        :param str password:    Optional password for HTTP
         :param int port:        Port to connect to. Default 80.
         """
         self._host = host
@@ -49,10 +50,18 @@ class ProjectorHttp(BaseProjectorConnection):
             "Referer": f"http://{self._host}:{port}/cgi-bin/webconf",
         }
         self._serial = None
-        self.websession = websession
 
-    def close(self):
-        return
+        middlewares = []
+        if password:
+            digest_auth = aiohttp.DigestAuthMiddleware(
+                login="EPSONWEB", password=password
+            )
+            middlewares.append(digest_auth)
+
+        self.websession = aiohttp.ClientSession(middlewares=middlewares)
+
+    async def close(self):
+        await self.websession.close()
 
     async def get_property(self, command, timeout):
         """Get property state from device."""

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -71,7 +71,7 @@ class ProjectorSerial(BaseProjectorConnection):
         _LOGGER.error("Cannot open serial to Epson")
         return False
 
-    def close(self):
+    async def close(self):
         if self._writer and not self._writer.is_closing():
             _LOGGER.debug("Closing serial connection")
             self._writer.close()
@@ -126,7 +126,7 @@ class ProjectorSerial(BaseProjectorConnection):
                 self._check_timeout_reconnect()
             except (serialx.SerialException, OSError) as se:
                 _LOGGER.error("Error during serial write/read: %s", se)
-                self.close()
+                await self.close()
 
         return False
 

--- a/epson_projector/projector_serial.py
+++ b/epson_projector/projector_serial.py
@@ -72,13 +72,24 @@ class ProjectorSerial(BaseProjectorConnection):
         return False
 
     async def close(self):
-        if self._writer and not self._writer.is_closing():
-            _LOGGER.debug("Closing serial connection")
-            self._writer.close()
-            await self._writer.wait_closed()
-            self._writer = None
-            self._isOpen = False
-            self._timeouts = 0
+        if not self._writer:
+            return
+
+        _LOGGER.debug("Closing serial connection")
+        writer = self._writer
+        self._writer = None
+        self._isOpen = False
+        self._timeouts = 0
+
+        try:
+            if not writer.is_closing():
+                writer.close()
+            await writer.wait_closed()
+        except OSError as e:
+            # A peer can close the socket before wait_closed() resolves.
+            _LOGGER.debug("Serial connection closed by peer while closing: %s", e)
+        except serialx.SerialException as e:
+            _LOGGER.warning("Serial exception while closing connection: %s", e)
 
     def _check_timeout_reconnect(self):
         if self._timeouts >= MAX_TIMEOUTS:

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -60,7 +60,7 @@ class ProjectorTcp(BaseProjectorConnection):
         except EscVpNetConnectionError as e:
             raise ProjectorUnavailableError("Connection error") from e
 
-    def close(self) -> None:
+    async def close(self) -> None:
         if self._isOpen:
             self._writer.close()
 

--- a/test_http.py
+++ b/test_http.py
@@ -30,6 +30,8 @@ async def main_web(args):
     # data = await projector.send_request("EEMP0100À¨E")
     # print(data)
 
+    await projector.close()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/test_http.py
+++ b/test_http.py
@@ -15,29 +15,20 @@ _LOGGER = logging.getLogger(__name__)
 async def main_web(args):
     """Run main with aiohttp ClientSession."""
 
-    middlewares = []
-    if args.password:
-        _LOGGER.info("Using password for authentication")
-        digest_auth = aiohttp.DigestAuthMiddleware(
-            login="EPSONWEB", password=args.password
-        )
-        middlewares.append(digest_auth)
+    """Use Projector class of epson module and check if it is turned on."""
+    projector = epson.Projector.create_http(
+        host=args.host,
+        password=args.password,
+        port=args.port,
+    )
 
-    async with aiohttp.ClientSession(middlewares=middlewares) as websession:
-        """Use Projector class of epson module and check if it is turned on."""
-        projector = epson.Projector(
-            host=args.host,
-            websession=websession,
-            type="http",
-            http_port=args.port,
-        )
-        data = await projector.get_property(POWER)
-        print(data)
-        data = await projector.get_serial_number()
-        print(data)
-    #    await projector.send_command(PWR_ON)
-        # data = await projector.send_request("EEMP0100À¨E")
-        # print(data)
+    data = await projector.get_property(POWER)
+    print(data)
+    data = await projector.get_serial_number()
+    print(data)
+#    await projector.send_command(PWR_ON)
+    # data = await projector.send_request("EEMP0100À¨E")
+    # print(data)
 
 
 if __name__ == "__main__":

--- a/test_serial.py
+++ b/test_serial.py
@@ -35,7 +35,8 @@ async def main_serial(args):
 
     serialno = await projector.get_serial_number()
     print("Projector serial number:", serialno)
-    projector.close()
+
+    await projector.close()
 
 
 if __name__ == "__main__":

--- a/test_serial.py
+++ b/test_serial.py
@@ -18,9 +18,10 @@ logging.basicConfig(level=logging.DEBUG)
 
 async def main_serial(args):
     """Run main with serial connection."""
-    projector = epson.Projector(host=args.serial_url,
-                                type='serial',
-                                timeout_scale=2.0)
+    projector = epson.Projector.create_serial(
+        url=args.serial_url,
+        timeout_scale=2.0
+    )
     data = await projector.get_power()
     print(data)
     cmd = None

--- a/test_tcp.py
+++ b/test_tcp.py
@@ -13,7 +13,7 @@ async def main_tcp(args):
     if args.password:
         password = getpass()
 
-    projector = epson.Projector(host=args.host, type='tcp', tcp_password=password)
+    projector = epson.Projector.create_escvpnet(host=args.host, password=password)
 
     data = await projector.get_power()
     print("Power:", data)

--- a/test_tcp.py
+++ b/test_tcp.py
@@ -26,7 +26,7 @@ async def main_tcp(args):
 
     # await projector.send_command(PWR_OFF)
 
-    projector.close()
+    await projector.close()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(  # noqa: F821

--- a/tests/test_http_behavior.py
+++ b/tests/test_http_behavior.py
@@ -7,8 +7,9 @@ import aiohttp
 import asyncio
 import pytest
 
-from epson_projector.const import BUSY, HTTP, POWER
+from epson_projector.const import BUSY, POWER
 from epson_projector.error import ProjectorUnavailableError
+from epson_projector.projector_http import ProjectorHttp
 from epson_projector.projector import Projector
 
 
@@ -121,19 +122,22 @@ async def fake_serial_number_server():
 # ---------------------------------------------------------------------------
 
 async def test_get_power_reports_on_state():
-    projector = Projector("192.168.1.100", websession=_FakeSession(_ok(_power_on_json())), type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", _FakeSession(_ok(_power_on_json())))
+    projector = Projector(connection=connection)
     assert await projector.get_power() == "01"
 
 
 async def test_get_power_reports_off_state():
-    projector = Projector("192.168.1.100", websession=_FakeSession(_ok(_power_off_json())), type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", _FakeSession(_ok(_power_off_json())))
+    projector = Projector(connection=connection)
     assert await projector.get_power() == "04"
 
 
 async def test_get_power_preserves_last_good_value_after_server_error():
     """A 500 response is a soft failure; the cached power state is returned."""
     session = _FakeSession(_ok(_power_on_json()), _error_status(500))
-    projector = Projector("192.168.1.100", websession=session, type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", session)
+    projector = Projector(connection=connection)
 
     first = await projector.get_power()
     second = await projector.get_power()
@@ -143,12 +147,14 @@ async def test_get_power_preserves_last_good_value_after_server_error():
 
 
 async def test_get_property_returns_value_for_arbitrary_command():
-    projector = Projector("192.168.1.100", websession=_FakeSession(_ok(_cmode_json("15"))), type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", _FakeSession(_ok(_cmode_json("15"))))
+    projector = Projector(connection=connection)
     assert await projector.get_property("CMODE") == "15"
 
 
 async def test_network_error_raises_projector_unavailable():
-    projector = Projector("192.168.1.100", websession=_NetworkErrorSession(), type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", _NetworkErrorSession())
+    projector = Projector(connection=connection)
 
     with pytest.raises(ProjectorUnavailableError):
         await projector.get_property(POWER)
@@ -157,7 +163,8 @@ async def test_network_error_raises_projector_unavailable():
 async def test_get_property_returns_busy_immediately_after_send_command():
     """send_command acquires a timed lock; the next get_property returns BUSY."""
     session = _FakeSession(_ok({"status": "ok"}))
-    projector = Projector("192.168.1.100", websession=session, type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", session)
+    projector = Projector(connection=connection)
 
     await projector.send_command("PWR ON")
     assert await projector.get_property(POWER) == BUSY
@@ -166,7 +173,8 @@ async def test_get_property_returns_busy_immediately_after_send_command():
 async def test_send_command_returns_false_when_already_locked():
     """A second command while one is in-flight is rejected with False."""
     session = _FakeSession(_ok({"status": "ok"}))
-    projector = Projector("192.168.1.100", websession=session, type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", session)
+    projector = Projector(connection=connection)
 
     await projector.send_command("PWR ON")
     assert await projector.send_command("SOURCE") is False
@@ -174,7 +182,8 @@ async def test_send_command_returns_false_when_already_locked():
 
 async def test_send_request_returns_busy_while_locked():
     session = _FakeSession(_ok({"status": "ok"}))
-    projector = Projector("192.168.1.100", websession=session, type=HTTP)
+    connection = ProjectorHttp("192.168.1.100", session)
+    projector = Projector(connection=connection)
 
     await projector.send_command("PWR ON")
     assert await projector.send_request([("jsoncallback", "PWR?")]) == BUSY
@@ -183,7 +192,8 @@ async def test_send_request_returns_busy_while_locked():
 async def test_timeout_scale_does_not_break_get_property():
     """A projector configured for slower responses still returns the correct value."""
     session = _FakeSession(_ok(_power_on_json()))
-    projector = Projector("192.168.1.100", websession=session, type=HTTP, timeout_scale=2.0)
+    connection = ProjectorHttp("192.168.1.100", session)
+    projector = Projector(connection=connection, timeout_scale=2.0)
 
     assert await projector.get_property(POWER) == "01"
 
@@ -192,11 +202,8 @@ async def test_get_serial_number_returns_value_when_projector_is_on(
     fake_serial_number_server, monkeypatch
 ):
     session = _FakeSession(_ok(_power_on_json()))
-    projector = Projector(
-        fake_serial_number_server.host,
-        websession=session,
-        type=HTTP,
-    )
+    connection = ProjectorHttp(fake_serial_number_server.host, session)
+    projector = Projector(connection=connection)
 
     monkeypatch.setattr(
         "epson_projector.projector_http.TCP_SERIAL_PORT",

--- a/tests/test_http_behavior.py
+++ b/tests/test_http_behavior.py
@@ -46,11 +46,17 @@ class _FakeSession:
     def get(self, **kwargs):
         return next(self._responses)
 
+    async def close(self):
+        return None
+
 
 class _NetworkErrorSession:
     """Always raises a network error when .get() is called."""
     def get(self, **kwargs):
         raise aiohttp.ClientConnectionError("projector unreachable")
+
+    async def close(self):
+        return None
 
 
 def _ok(json_data):
@@ -81,6 +87,11 @@ def _power_off_json():
 
 def _cmode_json(code):
     return _query_json("CMODE?", code)
+
+
+def _make_http_connection(monkeypatch, session, host="192.168.1.100"):
+    monkeypatch.setattr("epson_projector.projector_http.aiohttp.ClientSession", lambda **kwargs: session)
+    return ProjectorHttp(host)
 
 
 class _FakeSerialNumberServer:
@@ -121,22 +132,22 @@ async def fake_serial_number_server():
 # Tests
 # ---------------------------------------------------------------------------
 
-async def test_get_power_reports_on_state():
-    connection = ProjectorHttp("192.168.1.100", _FakeSession(_ok(_power_on_json())))
+async def test_get_power_reports_on_state(monkeypatch):
+    connection = _make_http_connection(monkeypatch, _FakeSession(_ok(_power_on_json())))
     projector = Projector(connection=connection)
     assert await projector.get_power() == "01"
 
 
-async def test_get_power_reports_off_state():
-    connection = ProjectorHttp("192.168.1.100", _FakeSession(_ok(_power_off_json())))
+async def test_get_power_reports_off_state(monkeypatch):
+    connection = _make_http_connection(monkeypatch, _FakeSession(_ok(_power_off_json())))
     projector = Projector(connection=connection)
     assert await projector.get_power() == "04"
 
 
-async def test_get_power_preserves_last_good_value_after_server_error():
+async def test_get_power_preserves_last_good_value_after_server_error(monkeypatch):
     """A 500 response is a soft failure; the cached power state is returned."""
     session = _FakeSession(_ok(_power_on_json()), _error_status(500))
-    connection = ProjectorHttp("192.168.1.100", session)
+    connection = _make_http_connection(monkeypatch, session)
     projector = Projector(connection=connection)
 
     first = await projector.get_power()
@@ -146,53 +157,53 @@ async def test_get_power_preserves_last_good_value_after_server_error():
     assert second == "01"
 
 
-async def test_get_property_returns_value_for_arbitrary_command():
-    connection = ProjectorHttp("192.168.1.100", _FakeSession(_ok(_cmode_json("15"))))
+async def test_get_property_returns_value_for_arbitrary_command(monkeypatch):
+    connection = _make_http_connection(monkeypatch, _FakeSession(_ok(_cmode_json("15"))))
     projector = Projector(connection=connection)
     assert await projector.get_property("CMODE") == "15"
 
 
-async def test_network_error_raises_projector_unavailable():
-    connection = ProjectorHttp("192.168.1.100", _NetworkErrorSession())
+async def test_network_error_raises_projector_unavailable(monkeypatch):
+    connection = _make_http_connection(monkeypatch, _NetworkErrorSession())
     projector = Projector(connection=connection)
 
     with pytest.raises(ProjectorUnavailableError):
         await projector.get_property(POWER)
 
 
-async def test_get_property_returns_busy_immediately_after_send_command():
+async def test_get_property_returns_busy_immediately_after_send_command(monkeypatch):
     """send_command acquires a timed lock; the next get_property returns BUSY."""
     session = _FakeSession(_ok({"status": "ok"}))
-    connection = ProjectorHttp("192.168.1.100", session)
+    connection = _make_http_connection(monkeypatch, session)
     projector = Projector(connection=connection)
 
     await projector.send_command("PWR ON")
     assert await projector.get_property(POWER) == BUSY
 
 
-async def test_send_command_returns_false_when_already_locked():
+async def test_send_command_returns_false_when_already_locked(monkeypatch):
     """A second command while one is in-flight is rejected with False."""
     session = _FakeSession(_ok({"status": "ok"}))
-    connection = ProjectorHttp("192.168.1.100", session)
+    connection = _make_http_connection(monkeypatch, session)
     projector = Projector(connection=connection)
 
     await projector.send_command("PWR ON")
     assert await projector.send_command("SOURCE") is False
 
 
-async def test_send_request_returns_busy_while_locked():
+async def test_send_request_returns_busy_while_locked(monkeypatch):
     session = _FakeSession(_ok({"status": "ok"}))
-    connection = ProjectorHttp("192.168.1.100", session)
+    connection = _make_http_connection(monkeypatch, session)
     projector = Projector(connection=connection)
 
     await projector.send_command("PWR ON")
     assert await projector.send_request([("jsoncallback", "PWR?")]) == BUSY
 
 
-async def test_timeout_scale_does_not_break_get_property():
+async def test_timeout_scale_does_not_break_get_property(monkeypatch):
     """A projector configured for slower responses still returns the correct value."""
     session = _FakeSession(_ok(_power_on_json()))
-    connection = ProjectorHttp("192.168.1.100", session)
+    connection = _make_http_connection(monkeypatch, session)
     projector = Projector(connection=connection, timeout_scale=2.0)
 
     assert await projector.get_property(POWER) == "01"
@@ -202,7 +213,7 @@ async def test_get_serial_number_returns_value_when_projector_is_on(
     fake_serial_number_server, monkeypatch
 ):
     session = _FakeSession(_ok(_power_on_json()))
-    connection = ProjectorHttp(fake_serial_number_server.host, session)
+    connection = _make_http_connection(monkeypatch, session, host=fake_serial_number_server.host)
     projector = Projector(connection=connection)
 
     monkeypatch.setattr(

--- a/tests/test_serial_behavior.py
+++ b/tests/test_serial_behavior.py
@@ -131,3 +131,21 @@ async def test_serial_get_serial_number_returns_value():
     """get_serial_number delegates to the SNO property query over serial."""
     projector, _ = _make_projector_with_open_serial(b"SNO=XY12345678\r:")
     assert await projector.get_serial_number() == "XY12345678"
+
+
+async def test_serial_close_ignores_peer_closed_oserror():
+    """close() should not fail when the peer closes before wait_closed resolves."""
+
+    class _PeerClosedWriter(_FakeSerialWriter):
+        async def wait_closed(self) -> None:
+            raise OSError(5, "socket closed by peer")
+
+    connection = ProjectorSerial("/dev/ttyUSB0")
+    connection._writer = _PeerClosedWriter()
+    connection._isOpen = True
+
+    projector = Projector(connection=connection)
+    await projector.close()
+
+    assert connection._writer is None
+    assert connection._isOpen is False

--- a/tests/test_serial_behavior.py
+++ b/tests/test_serial_behavior.py
@@ -9,7 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
-from epson_projector.const import BUSY, POWER, SERIAL, SNO
+from epson_projector.const import BUSY, POWER, SNO
+from epson_projector.projector_serial import ProjectorSerial
 from epson_projector.projector import Projector
 
 
@@ -56,7 +57,8 @@ def _make_projector_with_open_serial(*responses: bytes) -> tuple[Projector, _Fak
     reader = _FakeSerialReader(*responses)
     writer = _FakeSerialWriter()
 
-    projector = Projector("/dev/ttyUSB0", type=SERIAL)
+    connection = ProjectorSerial("/dev/ttyUSB0")
+    projector = Projector(connection=connection)
     projector._projector._reader = reader
     projector._projector._writer = writer
     projector._projector._isOpen = True
@@ -102,7 +104,8 @@ async def test_serial_connection_is_established_when_not_open(monkeypatch):
         return reader, writer
 
     with patch("serialx.open_serial_connection", new=fake_open_serial_connection):
-        projector = Projector("/dev/ttyUSB0", type=SERIAL)
+        connection = ProjectorSerial("/dev/ttyUSB0")
+        projector = Projector(connection=connection)
         # _isOpen is False by default; first call triggers async_init
         value = await projector.get_property(POWER)
 

--- a/tests/test_tcp_behavior.py
+++ b/tests/test_tcp_behavior.py
@@ -8,7 +8,8 @@ from typing import AsyncGenerator
 
 import pytest
 
-from epson_projector.const import BUSY, POWER, TCP
+from epson_projector.const import BUSY, POWER
+from epson_projector.projector_tcp import ProjectorTcp
 from epson_projector.projector import Projector
 
 # Valid 16-byte Connect response: 
@@ -106,9 +107,8 @@ async def fake_serial_number_server() -> AsyncGenerator[_FakeSerialNumberServer,
 
 
 def _projector(fake: _FakeTcpProjector) -> Projector:
-    p = Projector(fake.host, type=TCP)
-    p._projector._port = fake.port   # override default 3629 with the ephemeral port
-    return p
+    connection = ProjectorTcp(fake.host, port=fake.port)
+    return Projector(connection=connection)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tcp_behavior.py
+++ b/tests/test_tcp_behavior.py
@@ -8,7 +8,7 @@ from typing import AsyncGenerator
 
 import pytest
 
-from epson_projector.const import BUSY, POWER, TCP
+from epson_projector.const import BUSY, POWER
 from epson_projector.imevent import AlarmType, ProjectorStatus, WarningType
 from epson_projector.projector import Projector
 from epson_projector.projector_tcp import ProjectorTcp


### PR DESCRIPTION
The construction of the Projector class got more complicated with adding the password support. For HTTP it needed to be setup manually in the websession outside of Projector, for TCP there was a `tcp_password` option.  So there were different sets of parameters needed for each type.

I reworked the construction of the Projector class so now it takes a `connection`. Each connection only takes the parameters it needs so it is clear what is needed for which one.

I added helper factorymethods to keep things simple for users of the package. They just call the helper and get a Projector.

Examples of typical calls

```python
projector = epson.Projector.create_http(host=HOSTNAME, password=PASSWORD_IF_NEEDED)
projector = epson.Projector.create_tcp(host=HOSTNAME, password=PASSWORD_IF_NEEDED)
projector = epson.Projector.create_serial(url=SERIAL_X_URL)
```

I ended up moving the websession into ProjectorHttp() see [757753e](https://github.com/pszafer/epson_projector/commit/757753e62c29efb6b0743d0eb74cb2af4c5e037b). Setting it up in the helper seemed a bit clumsy and in general having to setup the websession manually outside for the password seems weird. This package should make it easy to connect to a projector and manually managing the authentication on the websession is not easy.
However it does mean that for ProjectorHttp now also `projector.close()` needs to be called to close the now internal websession. Which makes it more consistent that close is needed for all.

There is also a small change to `close()` as it has become async to allow awaiting the closing of the session and also needed to properly await closes on the other protocols