### PR TITLE
Handle IMEVENT push message on ESC/VP.net

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -32,6 +32,10 @@ ESC/VP.net is used with projectors connected over a network. It uses a TCP socke
 
 Searching for ESC/VP.net result in this specification <https://archive.org/details/manualzz-id-1050273/mode/2up>
 
+ESC/VP.net adds a number of additional commands to the ESC/VP21 command set. These are mostly commands to set/get network related configuration. Check the specification for the full list. Not every command is implemented on all projectors.
+
+ESC/VP.net can push status updates with the IMEVENT message. This message can be sent at any time, so also inbetween request and its response. The IMEVENT message contains info about the power status, warnings and alerts. It seems like a message gets pushed when there is a change in any of those. The format is the same as the response to the `PWSTATUS?` command. Check the specification for details on the formatting.
+
 ### Serial
 
 This connection method is implemented in `protocol_serial.py`

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -34,7 +34,7 @@ Searching for ESC/VP.net result in this specification <https://archive.org/detai
 
 ESC/VP.net adds a number of additional commands to the ESC/VP21 command set. These are mostly commands to set/get network related configuration. Check the specification for the full list. Not every command is implemented on all projectors.
 
-ESC/VP.net can push status updates with the IMEVENT message. This message can be sent at any time, so also inbetween request and its response. The IMEVENT message contains info about the power status, warnings and alerts. It seems like a message gets pushed when there is a change in any of those. The format is the same as the response to the `PWSTATUS?` command. Check the specification for details on the formatting.
+ESC/VP.net can push status updates with the IMEVENT message. This message can be sent at any time, so also in between request and its response. The IMEVENT message contains info about the power status, warnings and alarms. It seems like a message gets pushed when there is a change in any of those. The format is the same as the response to the `PWSTATUS?` command. Check the specification for details on the formatting.
 
 ### Serial
 

--- a/epson_projector/imevent.py
+++ b/epson_projector/imevent.py
@@ -1,0 +1,93 @@
+"""This module defines the IMEVENT message and related enums."""
+
+from __future__ import annotations
+
+from enum import IntEnum, IntFlag
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ProjectorStatus(IntEnum):
+    STANDBY = 0x01
+    WARMUP = 0x02
+    NORMAL = 0x03
+    COOLDOWN = 0x04
+    ABNORMAL = 0xFF
+
+    _UNKNOWN = -1
+
+    @classmethod
+    def _missing_(cls, value: object) -> ProjectorStatus:
+        _LOGGER.warning("Unknown value '%s' for %s", value, cls.__name__)
+        return cls._UNKNOWN
+
+
+class WarningType(IntFlag):
+    LAMP_LIFE = 0x01
+    NO_SIGNAL = 0x02
+    UNSUPPORTED_SIGNAL = 0x04
+    AIR_FILTER = 0x08
+    HIGH_TEMPERATURE = 0x10
+    ASPECT_CHANGE = 0x40
+
+
+class AlarmType(IntFlag):
+    LAMP_ON_FAILURE = 0x01
+    LAMP_LID = 0x02
+    LAMP_BURNOUT = 0x04
+    FAN = 0x08
+    TEMPERATURE_SENSOR = 0x10
+    HIGH_TEMPERATURE = 0x20
+    INTERIOR_SYSTEM = 0x40
+
+
+class ImEvent:
+    def __init__(
+        self,
+        event_code: int,
+        power_status: ProjectorStatus,
+        warning_type: WarningType,
+        alarm_type: AlarmType,
+    ):
+        self.event_code = event_code
+        self.power_status = power_status
+        self.warning_type = warning_type
+        self.alarm_type = alarm_type
+
+    def __str__(self) -> str:
+        return f"ImEvent(event_code={self.event_code}, power_status={self.power_status}, warning_type={self.warning_type}, alarm_type={self.alarm_type})"
+
+    @staticmethod
+    def from_message(raw_message: bytes) -> ImEvent:
+        """Parse an IMEVENT message and return an ImEvent object."""
+
+        # Example message from LS11000
+        # b'IMEVENT=0001 03 00000002 00000000 T1 F1\r:'
+        message = raw_message.decode().rstrip("\r:")
+
+        (command, value) = message.split(sep="=", maxsplit=1)
+        if command != "IMEVENT":
+            raise ValueError(f"Command {command} is not IMEVENT")
+
+        parts = value.split()
+        if len(parts) < 4:
+            raise ValueError(
+                f"Expected at least eventcode and 3 parameters. Found {len(parts)} in message: {message}"
+            )
+
+        event_code = int(parts[0], 16)
+        if event_code != 1:
+            raise ValueError(f"Unknown event code: {event_code}")
+
+        # The parameters have 0 prefixes, so probably hex values.
+        power_status = ProjectorStatus(int(parts[1], 16))
+        warning_type = WarningType(int(parts[2], 16))
+        alarm_type = AlarmType(int(parts[3], 16))
+
+        return ImEvent(
+            event_code=event_code,
+            power_status=power_status,
+            warning_type=warning_type,
+            alarm_type=alarm_type,
+        )

--- a/epson_projector/imevent.py
+++ b/epson_projector/imevent.py
@@ -56,7 +56,7 @@ class ImEvent:
         self.alarm_type = alarm_type
 
     def __str__(self) -> str:
-        return f"ImEvent(event_code={self.event_code}, power_status={self.power_status}, warning_type={self.warning_type}, alarm_type={self.alarm_type})"
+        return f"ImEvent(event_code={self.event_code}, power_status={self.power_status}, warning_type={self.warning_type.name}, alarm_type={self.alarm_type.name})"
 
     @staticmethod
     def from_message(raw_message: bytes) -> ImEvent:
@@ -80,10 +80,12 @@ class ImEvent:
         if event_code != 1:
             raise ValueError(f"Unknown event code: {event_code}")
 
-        # The parameters have 0 prefixes, so probably hex values.
+        # Decode parameters
         power_status = ProjectorStatus(int(parts[1], 16))
         warning_type = WarningType(int(parts[2], 16))
         alarm_type = AlarmType(int(parts[3], 16))
+
+        # Any postfixes like T1 and F1 are discarded because the meaning is unknown.
 
         return ImEvent(
             event_code=event_code,

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -81,6 +81,7 @@ class ProjectorTcp(BaseProjectorConnection):
         """Listener task for messages coming from the projector."""
         while not writer.is_closing():
             try:
+                raw_response = await reader.readuntil(COLON.encode())
             except asyncio.IncompleteReadError:
                 _LOGGER.debug("EOF reached")
                 writer.close()

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -102,11 +102,9 @@ class ProjectorTcp(BaseProjectorConnection):
         except Exception as e:
             _LOGGER.error("Error in listener task: %s", e)
 
-    async def get_property(self, command, timeout, bytes_to_read=16) -> str | bool | int:
+    async def get_property(self, command, timeout) -> str | bool | int:
         """Get property state from device."""
-        response = await self.send_request(
-            timeout=timeout, params=command + GET_CR, bytes_to_read=bytes_to_read
-        )
+        response = await self.send_request(timeout=timeout, params=command + GET_CR)
         _LOGGER.debug("Response is %s", response)
         if not response:
             return False
@@ -127,7 +125,7 @@ class ProjectorTcp(BaseProjectorConnection):
         response = await self.send_request(timeout=timeout, params=command + CR)
         return response
 
-    async def send_request(self, timeout, params, bytes_to_read=16) -> str | bool | None:
+    async def send_request(self, timeout, params) -> str | bool | None:
         """Send TCP request to Epson."""
         if not self._writer:
             await self.async_init()

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -157,8 +157,7 @@ class ProjectorTcp(BaseProjectorConnection):
                     if pending_command_future := self._pending_request_future:
                         pending_command_future.cancel()
                     self._pending_request_future = None
-
-                    raise e
+                    raise
         return None
 
     async def get_serial_number(self) -> str | None:

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -45,11 +45,14 @@ class ProjectorTcp(BaseProjectorConnection):
         self._port = port
         self._password = password
         self._on_imevent = on_imevent
+
         self._serial = None
         self._listener_task = None
-        self._pending_command_future: asyncio.Future | None = None
-        self._request_lock = asyncio.Lock()
         self._writer: asyncio.StreamWriter | None = None
+
+        # Writing to pending_request should only be done from the `request` method within the lock
+        self._pending_request_future: asyncio.Future | None = None
+        self._request_lock = asyncio.Lock()
 
     async def async_init(self) -> None:
         """Async init to open connection with projector."""
@@ -83,7 +86,7 @@ class ProjectorTcp(BaseProjectorConnection):
                 _LOGGER.debug("EOF reached")
                 break
                 
-            _LOGGER.debug("Received: %s pending_command=%s", raw_response, self._pending_command_future is not None)
+            _LOGGER.debug("Received: %s", raw_response)
 
             # First handle supported unsolicited messages
             if raw_response.startswith(b"IMEVENT="):
@@ -95,8 +98,8 @@ class ProjectorTcp(BaseProjectorConnection):
                         _LOGGER.error("Error parsing IMEVENT: %s", e)
                 continue
 
-            # Must be response to pending command
-            if (future := self._pending_command_future) and not future.done():
+            # Should be response to pending command
+            if (future := self._pending_request_future) and not future.done():
                 future.set_result(raw_response)
                 continue
 
@@ -135,7 +138,7 @@ class ProjectorTcp(BaseProjectorConnection):
                 try:
                     async with asyncio.timeout(timeout):
                         pending_command = asyncio.get_running_loop().create_future()
-                        self._pending_command_future = pending_command
+                        self._pending_request_future = pending_command
 
                         raw_command = command.encode()
                         _LOGGER.debug("Sending: %s", raw_command)
@@ -150,9 +153,9 @@ class ProjectorTcp(BaseProjectorConnection):
                         return response
                 except asyncio.TimeoutError as e:
                     _LOGGER.error("Timeout error receiving response for command %s", command)
-                    if pending_command_future := self._pending_command_future:
+                    if pending_command_future := self._pending_request_future:
                         pending_command_future.cancel()
-                    self._pending_command_future = None
+                    self._pending_request_future = None
 
                     raise e
         return None

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -27,42 +27,6 @@ from .timeout import get_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
-
-class PendingCommand:
-    """Class to represent a pending command."""
-
-    def __init__(self, command: str):
-        self._command = command
-        self._future = asyncio.get_running_loop().create_future()
-
-    def cancel(self) -> None:
-        """Cancel the pending command."""
-        if not self._future.done():
-            self._future.cancel()
-
-    async def wait_for_response(self) -> bytes:
-        """Wait for the response of the command."""
-        return await self._future
-
-    def handle_response(self, response: bytes) -> bool:
-        """Handle response if reponse to this command. Return True if handled, False otherwise."""
-
-        is_response = False
-
-        if response == b"ERR\r:":
-            is_response = True
-        elif self._command.endswith("?\r"): # Get command
-            if response.startswith(f"{self._command[:-2]}=".encode()):
-                is_response = True
-        elif response == b":": # This is set or null command
-            is_response = True
-
-        if is_response and not self._future.done():
-            self._future.set_result(response)
-
-        return is_response
-        
-
 class ProjectorTcp(BaseProjectorConnection):
     """
     Epson TCP connector
@@ -84,7 +48,7 @@ class ProjectorTcp(BaseProjectorConnection):
         self._isOpen = False
         self._serial = None
         self._listener_task = None
-        self._pending_command: PendingCommand | None = None
+        self._pending_command_future: asyncio.Future | None = None
 
     async def async_init(self) -> None:
         """Async init to open connection with projector."""
@@ -110,15 +74,16 @@ class ProjectorTcp(BaseProjectorConnection):
         """Listener task for messages coming from the projector."""
         try:
             while not writer.is_closing():
-                raw_response = await reader.readuntil(COLON.encode())
-                _LOGGER.debug("Received: %s pending_command=%s)", raw_response, self._pending_command is not None)
+                try:
+                    raw_response = await reader.readuntil(COLON.encode())
+                except asyncio.IncompleteReadError:
+                    _LOGGER.debug("EOF reached")
+                    return
+                    
+                _LOGGER.debug("Received: %s pending_command=%s)", raw_response, self._pending_command_future is not None)
 
-                if (cmd := self._pending_command) and cmd.handle_response(raw_response):
-                    continue
-    
-                # Must be an unsolicited message
+                # First handle supported unsolicited messages
                 if raw_response.startswith(b"IMEVENT="):
-                    _LOGGER.info("Received IMEVENT: %s", raw_response)
                     if self._on_imevent:
                         try:
                             imevent = ImEvent.from_message(raw_response)
@@ -127,7 +92,13 @@ class ProjectorTcp(BaseProjectorConnection):
                             _LOGGER.error("Error parsing IMEVENT: %s", e)
                     continue
 
-                _LOGGER.warning("Received unexpected message: %s", raw_response)
+                # Must be response to pending command
+                if (future := self._pending_command_future) and not future.done():
+                    future.set_result(raw_response)
+                    self._pending_command_future = None
+                    continue
+    
+                _LOGGER.warning("Received message while nothing pending: %s", raw_response)
         except Exception as e:
             _LOGGER.error("Error in listener task: %s", e)
 
@@ -165,27 +136,26 @@ class ProjectorTcp(BaseProjectorConnection):
             try:
                 async with asyncio.timeout(timeout):
                     # Note that command has ?\r already appended
-                    pending_command = PendingCommand(params)
-                    self._pending_command = pending_command
+                    pending_command = asyncio.get_running_loop().create_future()
+                    self._pending_command_future = pending_command
 
                     raw_command = params.encode()
                     _LOGGER.debug("Sending: %s", raw_command)
-
                     self._writer.write(raw_command)
                     await self._writer.drain()
 
-                    # response = await self._reader.read(bytes_to_read)
-                    response = await pending_command.wait_for_response()
+                    response = await pending_command
                     response = response.decode().replace(CR_COLON, "")
+
                     if response == ERROR:
                         return False
                     return response
             except asyncio.TimeoutError as e:
                 _LOGGER.error("Timeout error receiving response for command %s", params)
-                if pc := self._pending_command:
-                    pc.cancel()
-                self._pending_command = None
-                # Raise again to keep current behavior
+                if pending_command_future := self._pending_command_future:
+                    pending_command_future.cancel()
+                self._pending_command_future = None
+
                 raise e
         return None
 

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -7,11 +7,13 @@ import asyncio
 
 from epson_projector.error import ProjectorUnavailableError, UnauthorizedError
 from epson_projector.escvpnet.error import EscVpNetConnectionError, EscVpNetForbiddenStatus, EscVpNetUnauthorizedStatus
-from epson_projector.escvpnet.escvpnet import EscVpNet
+from epson_projector.escvpnet.escvpnet import ESC_VPNET_PORT, EscVpNet
+from epson_projector.imevent import ImEvent
 
 from .base_connection import BaseProjectorConnection
 from .const import (
     BUSY,
+    COLON,
     ERROR,
     CR,
     CR_COLON,
@@ -26,24 +28,63 @@ from .timeout import get_timeout
 _LOGGER = logging.getLogger(__name__)
 
 
+class PendingCommand:
+    """Class to represent a pending command."""
+
+    def __init__(self, command: str):
+        self._command = command
+        self._future = asyncio.get_running_loop().create_future()
+
+    def cancel(self) -> None:
+        """Cancel the pending command."""
+        if not self._future.done():
+            self._future.cancel()
+
+    async def wait_for_response(self) -> bytes:
+        """Wait for the response of the command."""
+        return await self._future
+
+    def handle_response(self, response: bytes) -> bool:
+        """Handle response if reponse to this command. Return True if handled, False otherwise."""
+
+        is_response = False
+
+        if response == b"ERR\r:":
+            is_response = True
+        elif self._command.endswith("?\r"): # Get command
+            if response.startswith(f"{self._command[:-2]}=".encode()):
+                is_response = True
+        elif response == b":": # This is set or null command
+            is_response = True
+
+        if is_response and not self._future.done():
+            self._future.set_result(response)
+
+        return is_response
+        
+
 class ProjectorTcp(BaseProjectorConnection):
     """
     Epson TCP connector
     """
 
-    def __init__(self, host, port=3629, password=None):
+    def __init__(self, host, port=ESC_VPNET_PORT, password=None, on_imevent=None):
         """
         Epson TCP connector
 
         :param str host:     IP address of Projector
         :param int port:     Port to connect to. Default 3629.
         :param str password: Password for the projector. Default None.
+        :param callable on_imevent: Callback for IMEVENT messages. Default None.
         """
         self._host = host
         self._port = port
         self._password = password
+        self._on_imevent = on_imevent
         self._isOpen = False
         self._serial = None
+        self._listener_task = None
+        self._pending_command: PendingCommand | None = None
 
     async def async_init(self) -> None:
         """Async init to open connection with projector."""
@@ -51,6 +92,7 @@ class ProjectorTcp(BaseProjectorConnection):
             async with asyncio.timeout(10):
                 escvpnet = EscVpNet(host=self._host, port=self._port, password=self._password)
                 self._reader, self._writer = await escvpnet.connect()
+                self._listener_task = asyncio.create_task(self._listener_task_impl(self._reader, self._writer))
                 self._isOpen = True
                 _LOGGER.info("Connection open")
         except asyncio.TimeoutError:
@@ -64,10 +106,35 @@ class ProjectorTcp(BaseProjectorConnection):
         if self._isOpen:
             self._writer.close()
 
+    async def _listener_task_impl(self, reader, writer) -> None:
+        """Listener task for messages coming from the projector."""
+        try:
+            while not writer.is_closing():
+                raw_response = await reader.readuntil(COLON.encode())
+                _LOGGER.debug("Received: %s pending_command=%s)", raw_response, self._pending_command is not None)
+
+                if (cmd := self._pending_command) and cmd.handle_response(raw_response):
+                    continue
+    
+                # Must be an unsolicited message
+                if raw_response.startswith(b"IMEVENT="):
+                    _LOGGER.info("Received IMEVENT: %s", raw_response)
+                    if self._on_imevent:
+                        try:
+                            imevent = ImEvent.from_message(raw_response)
+                            self._on_imevent(imevent)
+                        except ValueError as e:
+                            _LOGGER.error("Error parsing IMEVENT: %s", e)
+                    continue
+
+                _LOGGER.warning("Received unexpected message: %s", raw_response)
+        except Exception as e:
+            _LOGGER.error("Error in listener task: %s", e)
+
     async def get_property(self, command, timeout, bytes_to_read=16) -> str | bool | int:
         """Get property state from device."""
         response = await self.send_request(
-            timeout=timeout, command=command + GET_CR, bytes_to_read=bytes_to_read
+            timeout=timeout, params=command + GET_CR, bytes_to_read=bytes_to_read
         )
         _LOGGER.debug("Response is %s", response)
         if not response:
@@ -86,23 +153,40 @@ class ProjectorTcp(BaseProjectorConnection):
 
     async def send_command(self, command, timeout) -> str | bool | None:
         """Send command to Epson."""
-        response = await self.send_request(timeout=timeout, command=command + CR)
+        response = await self.send_request(timeout=timeout, params=command + CR)
         return response
 
-    async def send_request(self, timeout, command, bytes_to_read=16) -> str | bool | None:
+    async def send_request(self, timeout, params, bytes_to_read=16) -> str | bool | None:
         """Send TCP request to Epson."""
         if self._isOpen is False:
             await self.async_init()
-        if self._isOpen and command:
+        if self._isOpen and params:
             bytes_to_read = bytes_to_read if bytes_to_read else 16
-            async with asyncio.timeout(timeout):
-                self._writer.write(command.encode())
-                await self._writer.drain()
-                response = await self._reader.read(bytes_to_read)
-                response = response.decode().replace(CR_COLON, "")
-                if response == ERROR:
-                    return False
-                return response
+            try:
+                async with asyncio.timeout(timeout):
+                    # Note that command has ?\r already appended
+                    pending_command = PendingCommand(params)
+                    self._pending_command = pending_command
+
+                    raw_command = params.encode()
+                    _LOGGER.debug("Sending: %s", raw_command)
+
+                    self._writer.write(raw_command)
+                    await self._writer.drain()
+
+                    # response = await self._reader.read(bytes_to_read)
+                    response = await pending_command.wait_for_response()
+                    response = response.decode().replace(CR_COLON, "")
+                    if response == ERROR:
+                        return False
+                    return response
+            except asyncio.TimeoutError as e:
+                _LOGGER.error("Timeout error receiving response for command %s", params)
+                if pc := self._pending_command:
+                    pc.cancel()
+                self._pending_command = None
+                # Raise again to keep current behavior
+                raise e
         return None
 
     async def get_serial_number(self) -> str | None:

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -81,9 +81,10 @@ class ProjectorTcp(BaseProjectorConnection):
         """Listener task for messages coming from the projector."""
         while not writer.is_closing():
             try:
-                raw_response = await reader.readuntil(COLON.encode())
             except asyncio.IncompleteReadError:
                 _LOGGER.debug("EOF reached")
+                writer.close()
+                self._writer = None
                 break
                 
             _LOGGER.debug("Received: %s", raw_response)

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -48,6 +48,7 @@ class ProjectorTcp(BaseProjectorConnection):
         self._serial = None
         self._listener_task = None
         self._pending_command_future: asyncio.Future | None = None
+        self._request_lock = asyncio.Lock()
         self._writer: asyncio.StreamWriter | None = None
 
     async def async_init(self) -> None:
@@ -131,29 +132,30 @@ class ProjectorTcp(BaseProjectorConnection):
             await self.async_init()
 
         if self._writer and command:
-            try:
-                async with asyncio.timeout(timeout):
-                    pending_command = asyncio.get_running_loop().create_future()
-                    self._pending_command_future = pending_command
+            async with self._request_lock:
+                try:
+                    async with asyncio.timeout(timeout):
+                        pending_command = asyncio.get_running_loop().create_future()
+                        self._pending_command_future = pending_command
 
-                    raw_command = command.encode()
-                    _LOGGER.debug("Sending: %s", raw_command)
-                    self._writer.write(raw_command)
-                    await self._writer.drain()
+                        raw_command = command.encode()
+                        _LOGGER.debug("Sending: %s", raw_command)
+                        self._writer.write(raw_command)
+                        await self._writer.drain()
 
-                    response = await pending_command
-                    response = response.decode().replace(CR_COLON, "")
+                        response = await pending_command
+                        response = response.decode().replace(CR_COLON, "")
 
-                    if response == ERROR:
-                        return False
-                    return response
-            except asyncio.TimeoutError as e:
-                _LOGGER.error("Timeout error receiving response for command %s", command)
-                if pending_command_future := self._pending_command_future:
-                    pending_command_future.cancel()
-                self._pending_command_future = None
+                        if response == ERROR:
+                            return False
+                        return response
+                except asyncio.TimeoutError as e:
+                    _LOGGER.error("Timeout error receiving response for command %s", command)
+                    if pending_command_future := self._pending_command_future:
+                        pending_command_future.cancel()
+                    self._pending_command_future = None
 
-                raise e
+                    raise e
         return None
 
     async def get_serial_number(self) -> str | None:

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -67,41 +67,40 @@ class ProjectorTcp(BaseProjectorConnection):
             raise ProjectorUnavailableError("Connection error") from e
 
     def close(self) -> None:
+        if self._listener_task:
+            self._listener_task.cancel()
+            self._listener_task = None
         if self._writer:
             self._writer.close()
             self._writer = None
 
     async def _listener_task_impl(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Listener task for messages coming from the projector."""
-        try:
-            while not writer.is_closing():
-                try:
-                    raw_response = await reader.readuntil(COLON.encode())
-                except asyncio.IncompleteReadError:
-                    _LOGGER.debug("EOF reached")
-                    return
-                    
-                _LOGGER.debug("Received: %s pending_command=%s)", raw_response, self._pending_command_future is not None)
+        while not writer.is_closing():
+            try:
+                raw_response = await reader.readuntil(COLON.encode())
+            except asyncio.IncompleteReadError:
+                _LOGGER.debug("EOF reached")
+                break
+                
+            _LOGGER.debug("Received: %s pending_command=%s", raw_response, self._pending_command_future is not None)
 
-                # First handle supported unsolicited messages
-                if raw_response.startswith(b"IMEVENT="):
-                    if self._on_imevent:
-                        try:
-                            imevent = ImEvent.from_message(raw_response)
-                            self._on_imevent(imevent)
-                        except ValueError as e:
-                            _LOGGER.error("Error parsing IMEVENT: %s", e)
-                    continue
+            # First handle supported unsolicited messages
+            if raw_response.startswith(b"IMEVENT="):
+                if self._on_imevent:
+                    try:
+                        imevent = ImEvent.from_message(raw_response)
+                        self._on_imevent(imevent)
+                    except ValueError as e:
+                        _LOGGER.error("Error parsing IMEVENT: %s", e)
+                continue
 
-                # Must be response to pending command
-                if (future := self._pending_command_future) and not future.done():
-                    future.set_result(raw_response)
-                    self._pending_command_future = None
-                    continue
-    
-                _LOGGER.warning("Received message while nothing pending: %s", raw_response)
-        except Exception as e:
-            _LOGGER.error("Error in listener task: %s", e)
+            # Must be response to pending command
+            if (future := self._pending_command_future) and not future.done():
+                future.set_result(raw_response)
+                continue
+
+            _LOGGER.warning("Received message while nothing pending: %s", raw_response)
 
     async def get_property(self, command, timeout) -> str | bool | int:
         """Get property state from device."""

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -36,9 +36,9 @@ class ProjectorTcp(BaseProjectorConnection):
         """
         Epson TCP connector
 
-        :param str host:     IP address of Projector
-        :param int port:     Port to connect to. Default 3629.
-        :param str password: Password for the projector. Default None.
+        :param str      host:       IP address of Projector
+        :param int      port:       Port to connect to. Default 3629.
+        :param str      password:   Password for the projector. Default None.
         :param callable on_imevent: Callback for IMEVENT messages. Default None.
         """
         self._host = host
@@ -133,7 +133,6 @@ class ProjectorTcp(BaseProjectorConnection):
         if self._writer and command:
             try:
                 async with asyncio.timeout(timeout):
-                    # Note that command has ?\r already appended
                     pending_command = asyncio.get_running_loop().create_future()
                     self._pending_command_future = pending_command
 

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -45,19 +45,18 @@ class ProjectorTcp(BaseProjectorConnection):
         self._port = port
         self._password = password
         self._on_imevent = on_imevent
-        self._isOpen = False
         self._serial = None
         self._listener_task = None
         self._pending_command_future: asyncio.Future | None = None
+        self._writer: asyncio.StreamWriter | None = None
 
     async def async_init(self) -> None:
         """Async init to open connection with projector."""
         try:
             async with asyncio.timeout(10):
                 escvpnet = EscVpNet(host=self._host, port=self._port, password=self._password)
-                self._reader, self._writer = await escvpnet.connect()
-                self._listener_task = asyncio.create_task(self._listener_task_impl(self._reader, self._writer))
-                self._isOpen = True
+                reader, self._writer = await escvpnet.connect()
+                self._listener_task = asyncio.create_task(self._listener_task_impl(reader, self._writer))
                 _LOGGER.info("Connection open")
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout error")
@@ -67,10 +66,11 @@ class ProjectorTcp(BaseProjectorConnection):
             raise ProjectorUnavailableError("Connection error") from e
 
     def close(self) -> None:
-        if self._isOpen:
+        if self._writer:
             self._writer.close()
+            self._writer = None
 
-    async def _listener_task_impl(self, reader, writer) -> None:
+    async def _listener_task_impl(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Listener task for messages coming from the projector."""
         try:
             while not writer.is_closing():
@@ -129,10 +129,10 @@ class ProjectorTcp(BaseProjectorConnection):
 
     async def send_request(self, timeout, params, bytes_to_read=16) -> str | bool | None:
         """Send TCP request to Epson."""
-        if self._isOpen is False:
+        if not self._writer:
             await self.async_init()
-        if self._isOpen and params:
-            bytes_to_read = bytes_to_read if bytes_to_read else 16
+
+        if self._writer and params:
             try:
                 async with asyncio.timeout(timeout):
                     # Note that command has ?\r already appended

--- a/epson_projector/projector_tcp.py
+++ b/epson_projector/projector_tcp.py
@@ -104,7 +104,7 @@ class ProjectorTcp(BaseProjectorConnection):
 
     async def get_property(self, command, timeout) -> str | bool | int:
         """Get property state from device."""
-        response = await self.send_request(timeout=timeout, params=command + GET_CR)
+        response = await self.send_request(timeout=timeout, command=command + GET_CR)
         _LOGGER.debug("Response is %s", response)
         if not response:
             return False
@@ -122,22 +122,22 @@ class ProjectorTcp(BaseProjectorConnection):
 
     async def send_command(self, command, timeout) -> str | bool | None:
         """Send command to Epson."""
-        response = await self.send_request(timeout=timeout, params=command + CR)
+        response = await self.send_request(timeout=timeout, command=command + CR)
         return response
 
-    async def send_request(self, timeout, params) -> str | bool | None:
+    async def send_request(self, timeout, command) -> str | bool | None:
         """Send TCP request to Epson."""
         if not self._writer:
             await self.async_init()
 
-        if self._writer and params:
+        if self._writer and command:
             try:
                 async with asyncio.timeout(timeout):
                     # Note that command has ?\r already appended
                     pending_command = asyncio.get_running_loop().create_future()
                     self._pending_command_future = pending_command
 
-                    raw_command = params.encode()
+                    raw_command = command.encode()
                     _LOGGER.debug("Sending: %s", raw_command)
                     self._writer.write(raw_command)
                     await self._writer.drain()
@@ -149,7 +149,7 @@ class ProjectorTcp(BaseProjectorConnection):
                         return False
                     return response
             except asyncio.TimeoutError as e:
-                _LOGGER.error("Timeout error receiving response for command %s", params)
+                _LOGGER.error("Timeout error receiving response for command %s", command)
                 if pending_command_future := self._pending_command_future:
                     pending_command_future.cancel()
                 self._pending_command_future = None

--- a/tests/test_imevent.py
+++ b/tests/test_imevent.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from epson_projector.imevent import AlarmType, ImEvent, ProjectorStatus, WarningType
+
+
+@pytest.mark.parametrize(
+    ("raw_message", "power_status", "warning_type", "alarm_type"),
+    [
+        (
+            # Message captured from LS11000
+            b"IMEVENT=0001 03 00000002 00000000 T1 F1\r:",
+            ProjectorStatus.NORMAL,
+            WarningType.NO_SIGNAL,
+            AlarmType(0),
+        ),
+        (
+            # Message from ESC/VP.net documentation
+            b"IMEVENT=0001 01 0001 0001",
+            ProjectorStatus.STANDBY,
+            WarningType.LAMP_LIFE,
+            AlarmType.LAMP_ON_FAILURE,
+        ),
+    ],
+)
+def test_from_message_parses_known_imevent_formats(
+    raw_message: bytes,
+    power_status: ProjectorStatus,
+    warning_type: WarningType,
+    alarm_type: AlarmType,
+):
+    event = ImEvent.from_message(raw_message)
+
+    assert event.event_code == 1
+    assert event.power_status == power_status
+    assert event.warning_type == warning_type
+    assert event.alarm_type == alarm_type

--- a/tests/test_tcp_behavior.py
+++ b/tests/test_tcp_behavior.py
@@ -106,7 +106,7 @@ async def fake_serial_number_server() -> AsyncGenerator[_FakeSerialNumberServer,
 
 
 @pytest.fixture
-def projector(fake_projector_tcp: _FakeTcpProjector) -> Projector:
+async def projector(fake_projector_tcp: _FakeTcpProjector) -> AsyncGenerator[Projector, None]:
     p = Projector(fake_projector_tcp.host, type=TCP)
     p._projector._port = fake_projector_tcp.port  # override default 3629 with the ephemeral port
     try:

--- a/tests/test_tcp_behavior.py
+++ b/tests/test_tcp_behavior.py
@@ -9,7 +9,9 @@ from typing import AsyncGenerator
 import pytest
 
 from epson_projector.const import BUSY, POWER, TCP
+from epson_projector.imevent import AlarmType, ProjectorStatus, WarningType
 from epson_projector.projector import Projector
+from epson_projector.projector_tcp import ProjectorTcp
 
 # Valid 16-byte Connect response: 
 # bytes[0:10] == "ESC/VP.net"
@@ -172,3 +174,30 @@ async def test_tcp_get_serial_number_returns_value(
     )
 
     assert await projector.get_serial_number() == fake_serial_number_server.serial_number
+
+
+async def test_tcp_on_imevent_callback_triggered(fake_projector_tcp):
+    received = []
+
+    def on_imevent(event):
+        received.append(event)
+
+    projector_tcp = ProjectorTcp(
+        host=fake_projector_tcp.host,
+        port=fake_projector_tcp.port,
+        on_imevent=on_imevent,
+    )
+
+    fake_projector_tcp.queue(
+        b"IMEVENT=0001 03 00000002 00000000 T1 F1\r:PWR=01\r:"
+    )
+
+    try:
+        assert await projector_tcp.get_property(POWER, timeout=1) == "01"
+        assert len(received) == 1
+        assert received[0].event_code == 1
+        assert received[0].power_status == ProjectorStatus.NORMAL
+        assert received[0].warning_type == WarningType.NO_SIGNAL
+        assert received[0].alarm_type == AlarmType(0)
+    finally:
+        projector_tcp.close()

--- a/tests/test_tcp_behavior.py
+++ b/tests/test_tcp_behavior.py
@@ -105,28 +105,30 @@ async def fake_serial_number_server() -> AsyncGenerator[_FakeSerialNumberServer,
         await fake.close()
 
 
-def _projector(fake: _FakeTcpProjector) -> Projector:
-    p = Projector(fake.host, type=TCP)
-    p._projector._port = fake.port   # override default 3629 with the ephemeral port
-    return p
+@pytest.fixture
+def projector(fake_projector_tcp: _FakeTcpProjector) -> Projector:
+    p = Projector(fake_projector_tcp.host, type=TCP)
+    p._projector._port = fake_projector_tcp.port  # override default 3629 with the ephemeral port
+    try:
+        yield p
+    finally:
+        p.close()
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
-async def test_tcp_get_power_reports_on_state(fake_projector_tcp):
+async def test_tcp_get_power_reports_on_state(fake_projector_tcp, projector):
     fake_projector_tcp.queue(b"PWR=01\r:")
-    projector = _projector(fake_projector_tcp)
 
     assert await projector.get_power() == "01"
 
 
-async def test_tcp_get_power_preserves_cached_value_on_error_response(fake_projector_tcp):
+async def test_tcp_get_power_preserves_cached_value_on_error_response(fake_projector_tcp, projector):
     """When the projector replies with ERR, the cached power value is returned."""
     fake_projector_tcp.queue(b"PWR=01\r:")
     fake_projector_tcp.queue(b"ERR\r:")
-    projector = _projector(fake_projector_tcp)
 
     first = await projector.get_power()
     second = await projector.get_power()
@@ -135,17 +137,15 @@ async def test_tcp_get_power_preserves_cached_value_on_error_response(fake_proje
     assert second == "01"
 
 
-async def test_tcp_get_property_returns_value(fake_projector_tcp):
+async def test_tcp_get_property_returns_value(fake_projector_tcp, projector):
     fake_projector_tcp.queue(b"PWR=01\r:")
-    projector = _projector(fake_projector_tcp)
 
     assert await projector.get_property(POWER) == "01"
 
 
-async def test_tcp_get_property_returns_busy_after_send_command(fake_projector_tcp):
+async def test_tcp_get_property_returns_busy_after_send_command(fake_projector_tcp, projector):
     """send_command acquires a timed lock; subsequent get_property returns BUSY."""
     fake_projector_tcp.queue(b":")
-    projector = _projector(fake_projector_tcp)
 
     await projector.send_command("PWR ON")
     result = await projector.get_property(POWER)
@@ -153,20 +153,18 @@ async def test_tcp_get_property_returns_busy_after_send_command(fake_projector_t
     assert result == BUSY
 
 
-async def test_tcp_send_command_rejected_while_locked(fake_projector_tcp):
+async def test_tcp_send_command_rejected_while_locked(fake_projector_tcp, projector):
     """A second send_command returns False when a lock is already active."""
     fake_projector_tcp.queue(b":")
-    projector = _projector(fake_projector_tcp)
 
     await projector.send_command("PWR ON")
     assert await projector.send_command("SOURCE") is False
 
 
 async def test_tcp_get_serial_number_returns_value(
-    fake_projector_tcp, fake_serial_number_server, monkeypatch
+    fake_projector_tcp, projector, fake_serial_number_server, monkeypatch
 ):
     fake_projector_tcp.queue(b"PWR=01\r:")
-    projector = _projector(fake_projector_tcp)
 
     monkeypatch.setattr(
         "epson_projector.projector_tcp.TCP_SERIAL_PORT",


### PR DESCRIPTION
It turns out that when connected through ESC/VP.net the projector can "push" a message by itself, so without a request. This breaks the assumption that messages from the projector are always because of a request and it will result in mismatches.

The IMEVENT is described in the ESC/VP.net documentation, but it was not very clear that it is a push message.
The message contains powerstatus, warnings and alarms. 

This PR adds handling of the IMEVENT push message.
